### PR TITLE
spec: select OpenRaft for HomeKV v1 M3

### DIFF
--- a/docs/adr/0002-openraft-consensus.md
+++ b/docs/adr/0002-openraft-consensus.md
@@ -1,0 +1,98 @@
+# ADR 0002 — Select OpenRaft for HomeKV v1 M3
+
+- Status: Accepted by Spec 0001 amendment
+- Date: 2026-08-25
+- Supersedes: the `raft-rs` implementation choice in the original Spec 0001 acceptance
+
+## Context
+
+HomeKV v1 needs a production-quality Raft implementation while keeping the project focused on database/data-plane engineering: memory layout, shard ownership, WAL/durability, networking, routing, failure behavior, snapshots, and eventually many Raft groups.
+
+The original v1 spec selected TiKV `raft-rs` because it is low-level, proven in TiKV, and gives the application precise control over persistence, messages, apply ordering, and Multi-Raft integration.
+
+During spec review we revisited OpenRaft as the alternative.
+
+## Decision
+
+Use **OpenRaft** for the M3 single-replicated-shard implementation.
+
+HomeKV will implement and own:
+
+- OpenRaft `RaftLogStorage` backed by HomeKV's WAL/log persistence
+- OpenRaft `RaftStateMachine` backed by the shard-owned in-memory engine
+- OpenRaft network integration backed by HomeKV transport/connection management
+- HomeKV durability acknowledgement rules
+- snapshot representation/integrity
+- routing, placement, observability, and database APIs
+
+The M3 child spec must pin the exact OpenRaft version and features.
+
+## Why OpenRaft
+
+### 1. Better v1 correctness/velocity boundary
+
+OpenRaft exposes storage, state-machine, and networking as explicit application extension points while handling more of the Raft orchestration itself. This leaves HomeKV substantial control over database-specific components without requiring HomeKV to reconstruct every `RawNode::Ready` persistence/send/apply sequence correctly.
+
+### 2. Linearizable reads are a first-class documented path
+
+OpenRaft documents `read_index` / read-log-id behavior for linearizable reads. HomeKV will start with that safe path and keep lease-based optimization disabled until separately specified and verified.
+
+### 3. Membership and snapshot plumbing are integrated
+
+Dynamic membership, learners, snapshot building/installation, and lifecycle behavior are closer to application-level APIs, reducing the amount of consensus plumbing HomeKV must build before it can test the actual database system.
+
+### 4. Still allows a custom data plane
+
+Selecting OpenRaft does not require adopting a generic KV storage engine or generic network protocol. HomeKV still controls the hot storage and transport implementations.
+
+## Why not `raft-rs` for M3
+
+`raft-rs` remains an excellent low-level consensus core and is proven by TiKV. Its `RawNode` / `Ready` model gives excellent control, but that control increases integration surface and correctness burden in M3.
+
+HomeKV's v1 differentiator is not the Raft algorithm itself. M3 should establish a correct, durable replicated shard as efficiently as possible so engineering effort can move to the memory engine, networking, Multi-Raft scheduling, and performance behavior.
+
+## Risks
+
+### OpenRaft API stability
+
+OpenRaft is still pre-1.0 and documents its API as unstable. HomeKV must pin versions and treat upgrades as reviewed changes.
+
+### Multi-Raft maturity
+
+`openraft-multi` exists for sharing routing/connections across groups, but the current line is pre-1.0/alpha. HomeKV will not assume it is production-ready merely because it exists.
+
+### Framework overhead
+
+A higher-level framework may add per-group tasks, channels, allocations, timers, or scheduling overhead that becomes visible at hundreds/thousands of groups.
+
+## Mandatory M4 escape gate
+
+M4 must measure the OpenRaft integration as the number of groups grows. At minimum:
+
+- bytes/group at idle and under load
+- task/future/timer count per group
+- idle CPU cost
+- active groups per core
+- transport connection sharing
+- throughput/core
+- p99 and p99.9 latency as group count grows
+- runtime/scheduler contention
+
+If OpenRaft cannot satisfy HomeKV's accepted scaling/performance requirements after reasonable integration optimization, the consensus adapter may be replaced through a new accepted spec amendment. That replacement must preserve the same consistency, durability, failure, and client-visible semantics.
+
+## Consequences
+
+- M3 implementation gets a smaller consensus-integration surface.
+- HomeKV can focus earlier on its database-specific durability/state/network design.
+- OpenRaft upgrades are pinned/reviewed rather than floated.
+- M4 explicitly becomes the point where OpenRaft's Multi-Raft suitability is proven rather than assumed.
+- `raft-rs` remains the primary fallback if low-level control becomes necessary based on measurement.
+
+## References
+
+- OpenRaft docs: https://docs.rs/openraft/
+- OpenRaft getting started/storage APIs: https://docs.rs/openraft/latest/openraft/docs/getting_started/
+- OpenRaft linearizable reads: https://docs.rs/openraft/latest/openraft/docs/protocol/read/
+- OpenRaft Multi-Raft adapter: https://docs.rs/openraft-multi/
+- TiKV raft-rs: https://github.com/tikv/raft-rs
+- raft-rs `RawNode`: https://docs.rs/raft/latest/raft/raw_node/struct.RawNode.html

--- a/specs/0001-homekv-v1/design.md
+++ b/specs/0001-homekv-v1/design.md
@@ -1,6 +1,6 @@
 # Spec 0001 — HomeKV v1 Design
 
-- Status: Accepted
+- Status: Accepted (amended for OpenRaft selection)
 - Requirements: `requirements.md`
 - Tracking issue: #7
 
@@ -15,9 +15,9 @@ client
   v
 node ingress
   |
-  +--> shard router --> shard worker --> raft-rs group --> WAL
-                           |                 |
-                           |                 +--> followers
+  +--> shard router --> shard worker --> OpenRaft group --> WAL
+                           |               |
+                           |               +--> followers
                            v
                      in-memory state
 ```
@@ -27,12 +27,12 @@ The design optimizes the healthy path without weakening the consistency contract
 ## 2. Requirement mapping
 
 - `REQ-SHARD-*` -> fixed logical shard space + versioned placement metadata
-- `REQ-CONS-*` -> leader-authoritative replicated state machine + safe ReadIndex path
-- `REQ-DUR-*` -> quorum-persisted Raft WAL + snapshots + deterministic replay
+- `REQ-CONS-*` -> leader-authoritative replicated state machine + safe OpenRaft read barrier
+- `REQ-DUR-*` -> quorum-durable Raft log storage + snapshots + deterministic replay
 - `REQ-FAIL-*` -> consensus-controlled leadership/membership; gossip remains advisory
 - `REQ-PERF-*` -> shard-owned execution, no whole-store COW, batching, compact data plane
 - `REQ-OPS-*` -> per-shard consensus/data-plane metrics and topology inspection
-- `REQ-RAFT-*` -> TiKV `raft-rs` consensus core with HomeKV-owned integration
+- `REQ-RAFT-*` -> OpenRaft M3 integration with a mandatory M4 many-group scaling gate
 
 ## 3. Logical shards
 
@@ -68,28 +68,33 @@ The existing BTree/COW implementation remains the immutable M0 benchmark/control
 
 MVCC is not required for the default v1 contract. Future multi-version semantics require a dedicated spec.
 
-## 6. Consensus core
+## 6. Consensus integration
 
-Production v1 uses **TiKV `raft-rs`** as the Raft algorithm core. HomeKV intentionally owns the surrounding database machinery:
+Production v1 M3 uses **OpenRaft** as the Raft implementation.
 
-- persistent Raft log/WAL
-- transport
-- state machine
-- scheduling and batching
-- snapshots/recovery
-- metrics
-- logical-shard placement and routing
+HomeKV still owns the database-specific surrounding machinery through OpenRaft's application interfaces:
 
-The exact pinned crate/git revision and adapter APIs belong to Spec M3, so the dependency can be pinned reproducibly at implementation time.
+- `RaftLogStorage` implementation backed by HomeKV's durable WAL/log format
+- `RaftStateMachine` implementation backed by the shard-owned in-memory engine
+- `RaftNetwork`/network-factory integration using HomeKV's connection management and transport
+- snapshot encoding/storage/installation
+- request routing and redirect semantics
+- metrics and topology reporting
+- shard placement and Multi-Raft scheduling policy
 
-Why `raft-rs`:
+The exact pinned OpenRaft version, feature flags, storage adapter and network adapter belong to Spec M3 so the dependency can be frozen reproducibly at implementation time.
 
-- it is a low-level consensus core rather than a complete database framework;
-- it is used by TiKV and is suitable for many independent Raft groups;
-- HomeKV retains control over the hot replication, persistence and scheduling paths;
-- it avoids making bespoke consensus correctness a prerequisite for the database project.
+### Why OpenRaft for M3
 
-A from-scratch Raft may exist as a research subproject but is not the v1 correctness foundation.
+OpenRaft better matches HomeKV's v1 development objective than using the lower-level `raft-rs::RawNode` API directly:
+
+- storage, state-machine and network responsibilities are explicit application interfaces;
+- linearizable read APIs are documented as part of the framework;
+- membership changes, learner handling and snapshots are integrated rather than reconstructed around a raw consensus core;
+- it is async/event-driven and can batch internal work without requiring HomeKV to hand-roll the full Ready/persist/send/apply orchestration correctly;
+- it lets v1 spend engineering effort on database data-path behavior instead of consensus plumbing while retaining ownership of HomeKV-specific WAL/network/state-machine code.
+
+This is an integration choice, not a permanent performance assumption. Section 16 defines the M4 scaling gate.
 
 ## 7. Mutation path
 
@@ -97,21 +102,23 @@ For a replicated shard:
 
 1. client routes to the leader or receives a structured redirect;
 2. leader validates current authority/placement epoch;
-3. deterministic command is proposed to the `raft-rs` group;
-4. replicas persist the Raft Ready state before acknowledging replication success;
-5. quorum persistence allows the entry to become committed;
-6. leader applies the committed entry to its shard state machine;
-7. leader returns success.
+3. deterministic command is submitted through the OpenRaft client-write path;
+4. HomeKV's OpenRaft log store persists required Raft log/vote/committed state according to the accepted durability boundary;
+5. Raft establishes commitment through the configured quorum;
+6. OpenRaft invokes HomeKV's state machine to apply the committed entry;
+7. HomeKV returns success only after the accepted durable/apply boundary is satisfied.
 
-The initial durable path favors correctness and measurable semantics over minimum fsync latency. Group commit/batching optimizations are added only after this baseline path is verified.
+The M3 spec must explicitly verify that the chosen storage callback/flush semantics satisfy `REQ-DUR-005`; framework-level completion alone is not assumed to imply HomeKV's durable success contract.
+
+Group commit/batching optimizations are added only after the baseline durable path is verified.
 
 ## 8. Read path
 
 Default GET is linearizable.
 
-M3 starts with **safe quorum-backed ReadIndex/equivalent behavior**. A read is served only after the leader establishes the required read barrier and its local state machine has applied through that barrier.
+M3 starts with OpenRaft's safe linearizable read path using `read_index`, `get_read_log_id`, or the version-appropriate equivalent. A read is served only after the leader establishes the required read barrier and its local state machine has applied through that barrier.
 
-Lease-based leader-local reads are explicitly deferred. They may be introduced by a later performance spec only after assumptions about leadership, clocks/timing, pause behavior and failure tests are explicit.
+Lease-based leader-local reads are explicitly deferred. OpenRaft has leader-lease machinery, but HomeKV will not enable a lease fast path until a later performance spec defines and verifies its timing/leadership/pause assumptions.
 
 Follower reads are not part of the default v1 consistency API.
 
@@ -119,11 +126,11 @@ Follower reads are not part of the default v1 consistency API.
 
 The v1 durable acknowledgement contract is:
 
-> A successful distributed mutation response requires quorum-persisted Raft state and local leader application of the committed entry.
+> A successful distributed mutation response requires quorum-durable Raft persistence and local leader application of the committed entry.
 
-For the first Linux implementation, a replica counts an entry as persisted only after required log bytes and Raft hard-state metadata reach the configured durable WAL boundary and the corresponding durability operation (`fdatasync`, `fsync`, or verified equivalent) completes successfully.
+For the first Linux implementation, a replica counts an entry as durable only after required log bytes and Raft persistent metadata reach the configured durable WAL boundary and the corresponding durability operation (`fdatasync`, `fsync`, or verified equivalent) completes successfully.
 
-The `raft-rs` Ready processing order must preserve its persistence-before-message safety requirements. WAL records are checksummed. Snapshots include last-included index/term plus integrity metadata.
+The M3 OpenRaft storage adapter must map OpenRaft's log/vote/commit persistence callbacks to this boundary explicitly. WAL records are checksummed. Snapshots include last-included log identity plus integrity metadata.
 
 A future relaxed/memory-only mode must be explicitly named and cannot be compared as equivalent to the default durable mode.
 
@@ -133,7 +140,7 @@ The existing gossip/phi detector becomes a health-observation subsystem. It may 
 
 It may not elect a leader, promote a replica, mutate authoritative membership, or allow writes from local suspicion alone.
 
-Replica membership changes use Raft-safe configuration transitions. Placement metadata carries a monotonically increasing epoch/version.
+Replica membership changes use OpenRaft's Raft-safe membership transition APIs. Placement metadata carries a monotonically increasing epoch/version.
 
 ## 11. Client routing and retries
 
@@ -161,9 +168,10 @@ Recovery sequence:
 
 1. validate/load latest complete snapshot;
 2. restore shard state and included log metadata;
-3. replay valid subsequent WAL/log entries;
-4. participate in consensus only after state is coherent;
-5. never expose speculative/uncommitted entries as applied state.
+3. restore OpenRaft persistent state/log state;
+4. replay valid subsequent durable entries;
+5. participate in consensus only after state is coherent;
+6. never expose speculative/uncommitted entries as applied state.
 
 Exact snapshot/WAL segmentation details are specified in the persistence work under M3/M5.
 
@@ -172,7 +180,7 @@ Exact snapshot/WAL segmentation details are specified in the persistence work un
 Safe shard movement under M4:
 
 1. choose target replica placement;
-2. add learner/non-voting replica where supported;
+2. add learner/non-voting replica through OpenRaft membership APIs;
 3. transfer snapshot/log until caught up;
 4. commit membership change;
 5. optionally transfer leadership;
@@ -183,9 +191,11 @@ Foreground latency impact is part of verification.
 
 ## 15. Observability
 
-Per node/shard metrics should include requests/latency by operation, queue depth/backpressure, leader/role, term/epoch, commit/applied index, replication lag, batching, WAL sync latency, snapshot bytes/time, memory/key/value bytes, elections/leadership changes and gossip suspicion state.
+Per node/shard metrics should include requests/latency by operation, queue depth/backpressure, leader/role, term/epoch, commit/applied progress, replication lag, batching, WAL sync latency, snapshot bytes/time, memory/key/value bytes, elections/leadership changes and gossip suspicion state.
 
-## 16. Milestone boundaries
+OpenRaft metrics may feed these signals, but HomeKV exposes a database-oriented metrics contract rather than leaking framework-specific types as its public management API.
+
+## 16. Milestone boundaries and OpenRaft scaling gate
 
 ### M0 — Baseline
 
@@ -201,11 +211,25 @@ Owns framed wire protocol, pipelining, client/server routing metadata and redire
 
 ### M3 — One replicated shard
 
-Owns `raft-rs` adapter, three-replica transport, WAL persistence, safe ReadIndex, failover, snapshots sufficient for one group and recovery verification.
+Owns the OpenRaft adapter, three-replica transport, durable log storage, safe linearizable reads, membership basics, failover, snapshots sufficient for one group and recovery verification.
 
 ### M4 — Multi-Raft / placement
 
-Owns 1,024 logical shard placement, many Raft-group scheduling, rebalancing, placement epochs, shard-aware client routing and multi-group operational behavior.
+Owns 1,024 logical shard placement, many-group scheduling, rebalancing, placement epochs, shard-aware client routing and multi-group operational behavior.
+
+M4 MUST benchmark:
+
+- memory per Raft group
+- tasks/futures/timers per group
+- connection count and connection sharing
+- idle-group overhead
+- active groups per core
+- throughput/core and p99/p99.9 as group count grows
+- scheduler/runtime contention
+
+`openraft-multi` is a candidate connection-sharing adapter, not an assumed production dependency. Its current pre-1.0/alpha state requires explicit pinning and verification.
+
+If OpenRaft cannot meet the accepted M4 scaling/performance requirements after reasonable integration optimization, HomeKV may replace the consensus adapter through a new accepted spec amendment while keeping the same consistency/durability semantics.
 
 ### M5+
 
@@ -215,7 +239,7 @@ Owns persistence/operability hardening and performance optimization after the ba
 
 M0/M1 results are valid engineering evidence on any host whose metadata is recorded. CI results are regression signals, not release claims.
 
-The exact dedicated hardware/network profile for public comparative claims is deliberately selected and frozen by the release/comparison benchmark spec. This deferred machine selection does not weaken the correctness or architecture acceptance gates.
+The exact dedicated hardware/network profile for public comparative claims is deliberately selected and frozen by the release/comparison benchmark spec.
 
 ## 18. Alternatives considered
 
@@ -235,9 +259,9 @@ Rejected for the main write path because first mutation can clone the entire und
 
 Rejected by ADR 0001. Architecture is the higher-leverage bottleneck; Zig remains a measured hot-path option.
 
-### OpenRaft
+### TiKV `raft-rs`
 
-A credible alternative with higher-level application APIs and documented leader-lease support. HomeKV selects `raft-rs` because v1 intentionally wants lower-level control of WAL, transport, scheduling and eventual Multi-Raft behavior. The initial implementation still uses safe ReadIndex rather than chasing a lease fast path.
+Still a strong alternative. Its `RawNode`/`Ready` model gives very low-level control and it is proven in TiKV. HomeKV does not select it for M3 because that control also makes HomeKV responsible for more consensus orchestration and persistence/message ordering glue. The M4 scaling gate preserves the option to reconsider the adapter if OpenRaft framework overhead becomes a proven bottleneck.
 
 ### Build custom Raft first
 
@@ -247,8 +271,10 @@ Rejected for production v1 because correctness risk and verification cost are hi
 
 All acceptance-blocking design items are resolved or deliberately delegated to child specs:
 
-1. consensus core: TiKV `raft-rs`;
+1. consensus integration: OpenRaft for M3, with a mandatory M4 many-group scaling gate;
 2. shard space: 1,024 shards, XXH3-64 low 10 bits;
-3. durability: quorum durable WAL persistence + leader apply before success;
+3. durability: quorum-durable Raft persistence + leader apply before success;
 4. M1/M2/M3/M4 boundaries: fixed in section 16;
 5. benchmark authority: host metadata for development; dedicated release machine frozen later.
+
+See `docs/adr/0002-openraft-consensus.md` for the crate-selection rationale and escape criteria.

--- a/specs/0001-homekv-v1/requirements.md
+++ b/specs/0001-homekv-v1/requirements.md
@@ -1,6 +1,6 @@
 # Spec 0001 — HomeKV v1 Requirements
 
-- Status: Accepted
+- Status: Accepted (amended for OpenRaft selection)
 - Tracking issue: #7
 
 ## 1. Purpose
@@ -60,7 +60,7 @@ HomeKV v1 supports:
 
 **REQ-CONS-005** — During a network partition, a minority replica set MUST NOT independently become writable outside the consensus protocol.
 
-**REQ-CONS-006** — The first replicated v1 implementation MUST use a quorum-backed safe read barrier (ReadIndex or equivalent). Lease-based reads are deferred until a later accepted optimization spec verifies clock/leadership assumptions.
+**REQ-CONS-006** — The first replicated v1 implementation MUST use a quorum-backed safe read barrier (`read_index`, `get_read_log_id`, or equivalent). Lease-based reads are deferred until a later accepted optimization spec verifies leadership/timing assumptions.
 
 ## 5. Durability requirements
 
@@ -132,9 +132,13 @@ These are engineering targets rather than release claims until verified on contr
 
 ## 12. Consensus dependency
 
-**REQ-RAFT-001** — The production v1 consensus core MUST use TiKV `raft-rs` rather than a bespoke Raft implementation. The exact pinned revision/version and integration contract are owned by the M3 child spec.
+**REQ-RAFT-001** — The production v1 M3 consensus integration MUST use OpenRaft rather than a bespoke Raft implementation. The exact pinned OpenRaft version and integration contract are owned by the M3 child spec.
 
-**REQ-RAFT-002** — HomeKV owns the WAL, transport, state machine, scheduling, batching, observability and placement integration around the Raft core.
+**REQ-RAFT-002** — HomeKV MUST retain ownership of its database-specific Raft storage implementation, state machine, network transport/connection management, durability boundary, observability, scheduling, and placement integration through OpenRaft's extension interfaces.
+
+**REQ-RAFT-003** — M4 MUST benchmark and verify the many-group cost of the chosen OpenRaft integration, including per-group task/runtime overhead, connection sharing, memory/group, throughput/core, and tail latency. `openraft-multi` MAY be used, but its alpha/pre-1.0 status MUST NOT bypass this verification gate.
+
+**REQ-RAFT-004** — If the M4 scaling gate demonstrates that OpenRaft cannot meet HomeKV's accepted performance requirements after reasonable integration optimization, a new accepted consensus-adapter amendment MAY replace the crate without changing the externally visible consistency/durability requirements.
 
 ## 13. Milestone boundaries
 
@@ -144,9 +148,9 @@ These are engineering targets rather than release claims until verified on contr
 
 **REQ-SDD-003** — M2 defines/implements the low-overhead data-plane protocol and routing semantics without making Multi-Raft a dependency.
 
-**REQ-SDD-004** — M3 proves one 3-replica shard with Raft, WAL durability, safe linearizable reads, failover and recovery.
+**REQ-SDD-004** — M3 proves one 3-replica shard with OpenRaft, WAL durability, safe linearizable reads, failover and recovery.
 
-**REQ-SDD-005** — M4 scales the proven M3 machinery to the 1,024-shard placement/Multi-Raft architecture.
+**REQ-SDD-005** — M4 scales the proven M3 machinery to the 1,024-shard placement/Multi-Raft architecture and verifies OpenRaft's many-group cost.
 
 ## 14. Non-goals
 
@@ -164,10 +168,10 @@ HomeKV v1 does not require:
 
 ## 15. Acceptance decisions
 
-The acceptance-time questions are resolved as follows:
+The acceptance-time decisions are:
 
 1. **Logical shard space:** 1,024 shards; `XXH3_64(key) & 1023`; fixed at cluster bootstrap in v1.
-2. **Durable acknowledgement:** quorum-persisted Raft state plus local leader apply before response.
-3. **Consensus core:** TiKV `raft-rs`; exact pinned revision and integration details belong to M3.
+2. **Durable acknowledgement:** quorum-durable Raft persistence plus local leader apply before response.
+3. **Consensus integration:** OpenRaft for M3; exact pin/integration details belong to M3. M4 includes a mandatory many-group scaling gate and may trigger a later adapter amendment if evidence requires it.
 4. **Benchmark authority:** M0 records actual host metadata; release-claim hardware is selected and frozen by the release/comparison spec.
 5. **Retries:** unconditional PUT/DELETE/deterministic batches are idempotent and retriable; general exactly-once semantics are out of v1 scope.


### PR DESCRIPTION
## Summary

Amends accepted Spec 0001 to select **OpenRaft** for the M3 single-replicated-shard implementation instead of hard-coding TiKV `raft-rs`.

This is a spec-only change made before M3 implementation, following HomeKV's SDD rule that accepted architectural assumptions are amended before code depends on them.

## Why

OpenRaft gives HomeKV a better v1 correctness/velocity boundary:

- explicit application interfaces for Raft log storage, state machine, snapshots and network
- first-class documented linearizable read path
- integrated membership/learner/snapshot lifecycle
- async/event-driven orchestration
- HomeKV still owns WAL durability, in-memory state machine, network/connection management, routing, placement and observability

`raft-rs` remains a strong low-level fallback, but using `RawNode`/`Ready` directly would make HomeKV own more persistence/message/apply orchestration in M3.

## Performance safeguard

This PR does **not** assume OpenRaft is automatically the best 1,024-group implementation.

M4 now has a mandatory scaling gate covering:

- memory/group
- task/future/timer overhead
- idle CPU/group
- active groups/core
- connection sharing
- throughput/core
- p99/p99.9 as group count grows
- runtime/scheduler contention

`openraft-multi` is only a candidate because its current line is pre-1.0/alpha. If the measured OpenRaft integration cannot meet the accepted performance requirements after reasonable optimization, a later accepted adapter amendment can switch the consensus crate without weakening HomeKV's consistency/durability semantics.

## Changed contracts

- `REQ-RAFT-001`: OpenRaft is the M3 production integration
- `REQ-RAFT-003`: mandatory M4 many-group verification
- `REQ-RAFT-004`: evidence-based escape hatch for consensus adapter replacement
- `REQ-SDD-004/005`: M3/M4 wording updated accordingly
- `docs/adr/0002-openraft-consensus.md`: decision rationale and escape criteria

## Non-goals

- no M3 code is introduced here
- no lease-based read optimization is enabled
- no durability or linearizability requirement is weakened
