### PR TITLE
bench: add M0 Tonic/Tokio server baseline

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,15 +4,15 @@ This directory implements Spec 0002 (M0 prototype baseline).
 
 ## Current slice
 
-Implemented in the first M0 slice:
+Implemented:
 
 - BENCH-T1 — deterministic config/result schema and percentile helpers
 - BENCH-T2 — storage-only `BTreeStore` + `Mvcc` baseline
+- BENCH-T3 — existing Tonic/Tokio server/RPC baseline with client concurrency 1/8/32
 - BENCH-T5 — bounded CI smoke mode
 
 Still required before Spec 0002 can become Verified:
 
-- BENCH-T3 — existing Tonic/Tokio server/RPC baseline with client concurrency 1/8/32
 - BENCH-T4 — any additional memory/accounting metrics that are practical
 - BENCH-T6 — immutable full prototype result capture
 - BENCH-T7 — baseline analysis/summary
@@ -41,16 +41,55 @@ cargo run --release --bin hkvbench -- \
 
 Repeat the full run at least three times on the same controlled host before drawing conclusions. Preserve every run rather than selecting only the fastest one.
 
+## Full server/RPC baseline
+
+BENCH-T3 deliberately uses the existing public Tonic/Tokio server path. Start the prototype server unchanged in one shell:
+
+```bash
+cargo run --release --bin homekv -- \
+  --host 127.0.0.1 \
+  --port 20001 \
+  --public_host 127.0.0.1 \
+  --gossip_port 20002
+```
+
+Then run the checked-in server matrix from another shell:
+
+```bash
+cargo run --release --bin hkvbench -- \
+  --config benchmarks/configs/baseline-server.json \
+  --output benchmarks/results/m0/server-run-1.json
+```
+
+The server matrix covers:
+
+- 16-byte keys / 64-byte values at 1,000, 10,000, and 50,000 keys;
+- client concurrency 1, 8, and 32 for each primary dataset size;
+- GET, SET, DELETE, and deterministic 80% GET / 20% SET workloads;
+- 16-byte keys / 256-byte values at 10,000 keys and concurrency 8;
+- 32-byte keys / 1 KiB values at 10,000 keys and concurrency 8;
+- a 5-second target measured window per server workload cell.
+
+The harness preloads deterministic data through the public SET RPC before measurements. Preload is outside the measured window. Tonic clients are cloned per worker, each worker uses a deterministic seed derived from the global seed and worker id, and successful request latency samples are aggregated across workers.
+
+RPC failures and Tokio task/runtime failures are reported separately. `measured_operations` counts successful measured RPCs, while `attempted_operations` includes measured RPC attempts that returned an RPC failure. A worker task failure is reported in `runtime_failures`.
+
+The prototype server's existing per-request logging remains enabled. BENCH-T3 must preserve the server path rather than optimize it, so those costs are intentionally part of this historical baseline. The `process_rss_bytes` value in a server-layer result describes the `hkvbench` client process; server-process memory evidence belongs to BENCH-T4.
+
+Repeat the full server run at least three times on the same controlled host and retain every run.
+
 ## What is measured
 
-The current storage baseline intentionally exercises `Mvcc<BTreeStore>` exactly as the prototype uses it:
+The storage baseline intentionally exercises `Mvcc<BTreeStore>` exactly as the prototype uses it:
 
 - GET includes acquisition of the current MVCC read snapshot and a B-tree lookup.
 - SET updates an existing key and includes the first-write whole-store COW clone.
 - DELETE targets a guaranteed-missing key. This keeps dataset cardinality constant while still triggering the current write transaction's COW clone.
 - `read80_write20` deterministically mixes 80% GET and 20% SET.
 
-Storage concurrency is reported as 1 because the prototype serializes writers. Concurrent client behavior is measured separately by BENCH-T3 at the RPC layer.
+Storage concurrency is reported as 1 because the prototype serializes writers. Concurrent client behavior is measured separately at the RPC layer.
+
+For the server baseline, DELETE also targets a guaranteed-missing key so the dataset cardinality remains stable across concurrency/workload cells.
 
 ## Result semantics
 
@@ -62,4 +101,4 @@ Every result bundle is labeled:
 
 M0 is a single-node prototype baseline, not a distributed or strong-consistency benchmark. Public comparative HomeKV claims require the later distributed correctness and benchmark specs.
 
-The result includes the git SHA, Rust version, OS/kernel, CPU, logical CPU count, host memory where available, process RSS where available, workload parameters, measured operation count, throughput, and p50/p95/p99 latency.
+The result includes the git SHA, Rust version, OS/kernel, CPU, logical CPU count, host memory where available, benchmark-process RSS where available, workload parameters, attempted/successful operation counts, throughput, p50/p95/p99 latency, and failure counters.

--- a/benchmarks/configs/baseline-server.json
+++ b/benchmarks/configs/baseline-server.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "mode": "baseline",
+  "layer": "server",
+  "seed": 42,
+  "workloads": ["get", "set", "delete", "read80_write20"],
+  "warmup_operations": 10,
+  "server": {
+    "endpoint": "http://127.0.0.1:20001",
+    "duration_ms": 5000,
+    "preload_batch_size": 8192,
+    "cases": [
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 1000, "concurrency": 1 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 1000, "concurrency": 8 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 1000, "concurrency": 32 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 10000, "concurrency": 1 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 10000, "concurrency": 8 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 10000, "concurrency": 32 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 50000, "concurrency": 1 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 50000, "concurrency": 8 },
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 50000, "concurrency": 32 },
+      { "key_size": 16, "value_size": 256, "dataset_cardinality": 10000, "concurrency": 8 },
+      { "key_size": 32, "value_size": 1024, "dataset_cardinality": 10000, "concurrency": 8 }
+    ]
+  }
+}

--- a/src/bin/hkvbench.rs
+++ b/src/bin/hkvbench.rs
@@ -3,10 +3,22 @@ use clap::Parser;
 use homekv::storage::{BTreeStore, Mvcc, Store};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::Barrier;
+use tonic::transport::Channel;
+use tonic::Status;
+
+use homekv_service::home_kv_service_client::HomeKvServiceClient;
+use homekv_service::{DelRequest, GetRequest, Record, SetRequest};
+
+mod homekv_service {
+    tonic::include_proto!("homekv_service");
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -29,16 +41,39 @@ struct PayloadProfile {
     value_size: usize,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct ServerCase {
+    key_size: usize,
+    value_size: usize,
+    dataset_cardinality: usize,
+    concurrency: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ServerConfig {
+    endpoint: String,
+    duration_ms: u64,
+    #[serde(default = "default_preload_batch_size")]
+    preload_batch_size: usize,
+    cases: Vec<ServerCase>,
+}
+
 #[derive(Debug, Deserialize)]
 struct BenchConfig {
     schema_version: u32,
     mode: String,
+    #[serde(default = "default_layer")]
+    layer: String,
     seed: u64,
+    #[serde(default)]
     profiles: Vec<PayloadProfile>,
+    #[serde(default)]
     dataset_cardinalities: Vec<usize>,
     workloads: Vec<String>,
     warmup_operations: usize,
+    #[serde(default)]
     storage_operations: usize,
+    server: Option<ServerConfig>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -71,11 +106,15 @@ struct BenchResult {
     dataset_cardinality: usize,
     concurrency: usize,
     warmup_operations: usize,
+    attempted_operations: usize,
     measured_operations: usize,
     elapsed_ns: u64,
     throughput_ops_sec: f64,
     latency_ns: LatencyPercentiles,
     failures: u64,
+    rpc_failures: u64,
+    runtime_failures: u64,
+    server_endpoint: Option<String>,
     environment: EnvironmentMetadata,
     notes: Vec<String>,
 }
@@ -89,6 +128,12 @@ struct ResultBundle {
     results: Vec<BenchResult>,
 }
 
+#[derive(Debug)]
+struct ServerWorkerResult {
+    samples: Vec<u64>,
+    rpc_failures: u64,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
@@ -99,23 +144,11 @@ async fn main() -> Result<()> {
     validate_config(&config)?;
 
     let environment = collect_environment();
-    let mut results = Vec::new();
-
-    for profile in &config.profiles {
-        for &dataset_cardinality in &config.dataset_cardinalities {
-            for workload in &config.workloads {
-                let result = run_storage_case(
-                    &config,
-                    profile,
-                    dataset_cardinality,
-                    workload,
-                    environment.clone(),
-                )
-                .await?;
-                results.push(result);
-            }
-        }
-    }
+    let results = match config.layer.as_str() {
+        "storage" => run_storage_benchmark(&config, environment.clone()).await?,
+        "server" => run_server_benchmark(&config, environment.clone()).await?,
+        _ => unreachable!("validated layer"),
+    };
 
     let bundle = ResultBundle {
         schema_version: 1,
@@ -141,28 +174,20 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+fn default_layer() -> String {
+    "storage".to_string()
+}
+
+fn default_preload_batch_size() -> usize {
+    8192
+}
+
 fn validate_config(config: &BenchConfig) -> Result<()> {
     if config.schema_version != 1 {
         bail!("unsupported config schema_version {}", config.schema_version);
     }
     if config.mode != "smoke" && config.mode != "baseline" {
         bail!("mode must be 'smoke' or 'baseline'");
-    }
-    if config.profiles.is_empty() {
-        bail!("profiles must not be empty");
-    }
-    if config.dataset_cardinalities.is_empty()
-        || config.dataset_cardinalities.iter().any(|&n| n == 0)
-    {
-        bail!("dataset_cardinalities must contain positive values");
-    }
-    if config.storage_operations == 0 {
-        bail!("storage_operations must be positive");
-    }
-    for profile in &config.profiles {
-        if profile.key_size == 0 || profile.value_size == 0 {
-            bail!("key_size and value_size must be positive");
-        }
     }
     if config.workloads.is_empty() {
         bail!("workloads must not be empty");
@@ -173,7 +198,87 @@ fn validate_config(config: &BenchConfig) -> Result<()> {
             other => bail!("unsupported workload '{other}'"),
         }
     }
+
+    match config.layer.as_str() {
+        "storage" => validate_storage_config(config),
+        "server" => validate_server_config(config),
+        other => bail!("unsupported benchmark layer '{other}'"),
+    }
+}
+
+fn validate_storage_config(config: &BenchConfig) -> Result<()> {
+    if config.profiles.is_empty() {
+        bail!("storage profiles must not be empty");
+    }
+    if config.dataset_cardinalities.is_empty()
+        || config.dataset_cardinalities.iter().any(|&n| n == 0)
+    {
+        bail!("storage dataset_cardinalities must contain positive values");
+    }
+    if config.storage_operations == 0 {
+        bail!("storage_operations must be positive for the storage layer");
+    }
+    for profile in &config.profiles {
+        if profile.key_size == 0 || profile.value_size == 0 {
+            bail!("key_size and value_size must be positive");
+        }
+    }
     Ok(())
+}
+
+fn validate_server_config(config: &BenchConfig) -> Result<()> {
+    let server = config
+        .server
+        .as_ref()
+        .context("server configuration is required for the server layer")?;
+    if server.endpoint.trim().is_empty() {
+        bail!("server endpoint must not be empty");
+    }
+    if server.duration_ms == 0 {
+        bail!("server duration_ms must be positive");
+    }
+    if config.mode == "baseline" && server.duration_ms < 5000 {
+        bail!("baseline server duration_ms must be at least 5000");
+    }
+    if server.preload_batch_size == 0 {
+        bail!("server preload_batch_size must be positive");
+    }
+    if server.cases.is_empty() {
+        bail!("server cases must not be empty");
+    }
+    for case in &server.cases {
+        if case.key_size == 0
+            || case.value_size == 0
+            || case.dataset_cardinality == 0
+            || case.concurrency == 0
+        {
+            bail!("server case dimensions and concurrency must be positive");
+        }
+    }
+    Ok(())
+}
+
+async fn run_storage_benchmark(
+    config: &BenchConfig,
+    environment: EnvironmentMetadata,
+) -> Result<Vec<BenchResult>> {
+    let mut results = Vec::new();
+    for profile in &config.profiles {
+        for &dataset_cardinality in &config.dataset_cardinalities {
+            for workload in &config.workloads {
+                let result = run_storage_case(
+                    config,
+                    profile,
+                    dataset_cardinality,
+                    workload,
+                    environment.clone(),
+                )
+                .await?;
+                results.push(result);
+            }
+        }
+    }
+    Ok(results)
 }
 
 async fn run_storage_case(
@@ -251,6 +356,7 @@ async fn run_storage_case(
         dataset_cardinality,
         concurrency: 1,
         warmup_operations: config.warmup_operations,
+        attempted_operations: measured_operations,
         measured_operations,
         elapsed_ns: duration_ns(elapsed),
         throughput_ops_sec,
@@ -260,9 +366,351 @@ async fn run_storage_case(
             p99: percentile(&samples, 99.0),
         },
         failures: 0,
+        rpc_failures: 0,
+        runtime_failures: 0,
+        server_endpoint: None,
         environment,
         notes,
     })
+}
+
+async fn run_server_benchmark(
+    config: &BenchConfig,
+    environment: EnvironmentMetadata,
+) -> Result<Vec<BenchResult>> {
+    let server = config
+        .server
+        .as_ref()
+        .context("validated server configuration")?;
+    let base_client = HomeKvServiceClient::connect(server.endpoint.clone())
+        .await
+        .with_context(|| format!("failed to connect to HomeKV server at {}", server.endpoint))?;
+
+    let mut prepared = HashSet::new();
+    let mut results = Vec::new();
+
+    for case in &server.cases {
+        let keys = Arc::new(
+            (0..case.dataset_cardinality)
+                .map(|i| deterministic_key(config.seed, i as u64, case.key_size))
+                .collect::<Vec<_>>(),
+        );
+        let values = Arc::new(
+            (0..case.dataset_cardinality)
+                .map(|i| {
+                    deterministic_bytes(
+                        config.seed ^ 0xa5a5_a5a5_a5a5_a5a5,
+                        i as u64,
+                        case.value_size,
+                    )
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let dataset_identity = (case.key_size, case.value_size, case.dataset_cardinality);
+        if prepared.insert(dataset_identity) {
+            let mut preload_client = base_client.clone();
+            preload_server_dataset(
+                &mut preload_client,
+                &keys,
+                &values,
+                server.preload_batch_size,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to preload server dataset key={} value={} cardinality={}",
+                    case.key_size, case.value_size, case.dataset_cardinality
+                )
+            })?;
+        }
+
+        for workload in &config.workloads {
+            results.push(
+                run_server_case(
+                    config,
+                    server,
+                    case,
+                    workload,
+                    base_client.clone(),
+                    keys.clone(),
+                    values.clone(),
+                    environment.clone(),
+                )
+                .await?,
+            );
+        }
+    }
+
+    Ok(results)
+}
+
+async fn preload_server_dataset(
+    client: &mut HomeKvServiceClient<Channel>,
+    keys: &[String],
+    values: &[Vec<u8>],
+    batch_size: usize,
+) -> Result<()> {
+    for start in (0..keys.len()).step_by(batch_size) {
+        let end = (start + batch_size).min(keys.len());
+        let records = (start..end)
+            .map(|idx| Record {
+                key: keys[idx].clone(),
+                value: Some(values[idx].clone()),
+            })
+            .collect();
+        let response = client
+            .set(SetRequest { records })
+            .await
+            .context("server preload SET RPC failed")?
+            .into_inner();
+        if !response.succ {
+            bail!("server preload SET returned succ=false");
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_server_case(
+    config: &BenchConfig,
+    server: &ServerConfig,
+    case: &ServerCase,
+    workload: &str,
+    base_client: HomeKvServiceClient<Channel>,
+    keys: Arc<Vec<String>>,
+    values: Arc<Vec<Vec<u8>>>,
+    mut environment: EnvironmentMetadata,
+) -> Result<BenchResult> {
+    let missing_key = Arc::new("z".repeat(case.key_size));
+    let mut clients = (0..case.concurrency)
+        .map(|_| base_client.clone())
+        .collect::<Vec<_>>();
+
+    for (worker_id, client) in clients.iter_mut().enumerate() {
+        let mut rng = server_rng(
+            config.seed,
+            case.dataset_cardinality,
+            workload,
+            worker_id,
+        );
+        for _ in 0..config.warmup_operations {
+            execute_server_operation(
+                client,
+                &keys,
+                &values,
+                &missing_key,
+                workload,
+                &mut rng,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "server warmup failed for workload={workload} concurrency={} worker={worker_id}",
+                    case.concurrency
+                )
+            })?;
+        }
+    }
+
+    let barrier = Arc::new(Barrier::new(case.concurrency + 1));
+    let mut handles = Vec::with_capacity(case.concurrency);
+    for (worker_id, mut client) in clients.into_iter().enumerate() {
+        let barrier = barrier.clone();
+        let keys = keys.clone();
+        let values = values.clone();
+        let missing_key = missing_key.clone();
+        let workload = workload.to_string();
+        let duration = Duration::from_millis(server.duration_ms);
+        let mut rng = server_rng(
+            config.seed,
+            case.dataset_cardinality,
+            &workload,
+            worker_id,
+        );
+
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            let deadline = Instant::now() + duration;
+            let mut samples = Vec::new();
+            let mut rpc_failures = 0_u64;
+
+            while Instant::now() < deadline {
+                let op_start = Instant::now();
+                match execute_server_operation(
+                    &mut client,
+                    &keys,
+                    &values,
+                    &missing_key,
+                    &workload,
+                    &mut rng,
+                )
+                .await
+                {
+                    Ok(()) => samples.push(duration_ns(op_start.elapsed())),
+                    Err(_) => rpc_failures = rpc_failures.saturating_add(1),
+                }
+            }
+
+            ServerWorkerResult {
+                samples,
+                rpc_failures,
+            }
+        }));
+    }
+
+    barrier.wait().await;
+    let measured_start = Instant::now();
+    let mut samples = Vec::new();
+    let mut rpc_failures = 0_u64;
+    let mut runtime_failures = 0_u64;
+    for handle in handles {
+        match handle.await {
+            Ok(worker) => {
+                samples.extend(worker.samples);
+                rpc_failures = rpc_failures.saturating_add(worker.rpc_failures);
+            }
+            Err(_) => runtime_failures = runtime_failures.saturating_add(1),
+        }
+    }
+    let elapsed = measured_start.elapsed();
+    samples.sort_unstable();
+
+    environment.process_rss_bytes = process_rss_bytes();
+    let measured_operations = samples.len();
+    let attempted_operations = measured_operations.saturating_add(rpc_failures as usize);
+    let elapsed_seconds = elapsed.as_secs_f64();
+    let throughput_ops_sec = if elapsed_seconds > 0.0 {
+        measured_operations as f64 / elapsed_seconds
+    } else {
+        0.0
+    };
+    let failures = rpc_failures.saturating_add(runtime_failures);
+
+    let mut notes = vec![
+        "single-node prototype server baseline; not a distributed consistency result".to_string(),
+        "measures the existing public Tonic/Tokio RPC path without server optimization".to_string(),
+        "prototype per-request logging remains enabled because M0 preserves the existing server path".to_string(),
+        "process_rss_bytes describes the hkvbench client process; server-process memory is deferred to BENCH-T4"
+            .to_string(),
+        format!("server measured target window is {} ms per worker", server.duration_ms),
+    ];
+    if workload == "delete" {
+        notes.push(
+            "DELETE targets a guaranteed-missing key so dataset cardinality stays stable across the measured window"
+                .to_string(),
+        );
+    }
+
+    Ok(BenchResult {
+        layer: "server",
+        workload: workload.to_string(),
+        seed: config.seed,
+        key_size: case.key_size,
+        value_size: case.value_size,
+        dataset_cardinality: case.dataset_cardinality,
+        concurrency: case.concurrency,
+        warmup_operations: config.warmup_operations.saturating_mul(case.concurrency),
+        attempted_operations,
+        measured_operations,
+        elapsed_ns: duration_ns(elapsed),
+        throughput_ops_sec,
+        latency_ns: LatencyPercentiles {
+            p50: percentile(&samples, 50.0),
+            p95: percentile(&samples, 95.0),
+            p99: percentile(&samples, 99.0),
+        },
+        failures,
+        rpc_failures,
+        runtime_failures,
+        server_endpoint: Some(server.endpoint.clone()),
+        environment,
+        notes,
+    })
+}
+
+fn server_rng(seed: u64, dataset_cardinality: usize, workload: &str, worker_id: usize) -> SmallRng {
+    SmallRng::seed_from_u64(
+        seed ^ (dataset_cardinality as u64).rotate_left(17)
+            ^ workload_discriminator(workload)
+            ^ (worker_id as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15),
+    )
+}
+
+async fn execute_server_operation(
+    client: &mut HomeKvServiceClient<Channel>,
+    keys: &[String],
+    values: &[Vec<u8>],
+    missing_key: &str,
+    workload: &str,
+    rng: &mut SmallRng,
+) -> std::result::Result<(), Status> {
+    let idx = rng.gen_range(0..keys.len());
+    match workload {
+        "get" => server_get(client, &keys[idx]).await,
+        "set" => server_set(client, &keys[idx], values[(idx + 1) % values.len()].clone()).await,
+        "delete" => server_delete(client, missing_key).await,
+        "read80_write20" => {
+            if rng.gen_range(0..100_u32) < 80 {
+                server_get(client, &keys[idx]).await
+            } else {
+                server_set(client, &keys[idx], values[(idx + 1) % values.len()].clone()).await
+            }
+        }
+        _ => unreachable!("validated workload"),
+    }
+}
+
+async fn server_get(
+    client: &mut HomeKvServiceClient<Channel>,
+    key: &str,
+) -> std::result::Result<(), Status> {
+    let response = client
+        .get(GetRequest {
+            keys: vec![key.to_string()],
+        })
+        .await?
+        .into_inner();
+    if response.records.len() != 1 || response.records[0].value.is_none() {
+        return Err(Status::internal("benchmark expected one populated record"));
+    }
+    Ok(())
+}
+
+async fn server_set(
+    client: &mut HomeKvServiceClient<Channel>,
+    key: &str,
+    value: Vec<u8>,
+) -> std::result::Result<(), Status> {
+    let response = client
+        .set(SetRequest {
+            records: vec![Record {
+                key: key.to_string(),
+                value: Some(value),
+            }],
+        })
+        .await?
+        .into_inner();
+    if !response.succ {
+        return Err(Status::internal("benchmark SET returned succ=false"));
+    }
+    Ok(())
+}
+
+async fn server_delete(
+    client: &mut HomeKvServiceClient<Channel>,
+    key: &str,
+) -> std::result::Result<(), Status> {
+    let response = client
+        .del(DelRequest {
+            keys: vec![key.to_string()],
+        })
+        .await?
+        .into_inner();
+    if !response.succ {
+        return Err(Status::internal("benchmark DELETE returned succ=false"));
+    }
+    Ok(())
 }
 
 async fn populated_store(
@@ -340,6 +788,11 @@ async fn storage_delete(store: &Mvcc<BTreeStore>, key: &[u8]) -> Result<()> {
     write_txn.get_mut().delete(key)?;
     write_txn.commit().await;
     Ok(())
+}
+
+fn deterministic_key(seed: u64, ordinal: u64, len: usize) -> String {
+    String::from_utf8(deterministic_bytes(seed, ordinal, len))
+        .expect("deterministic benchmark keys are ASCII hex")
 }
 
 fn deterministic_bytes(seed: u64, ordinal: u64, len: usize) -> Vec<u8> {
@@ -462,6 +915,13 @@ mod tests {
         assert_ne!(a, c);
         assert_eq!(a.len(), 16);
         assert_eq!(deterministic_bytes(42, 7, 32).len(), 32);
+    }
+
+    #[test]
+    fn deterministic_server_key_is_ascii_and_sized() {
+        let key = deterministic_key(42, 7, 32);
+        assert_eq!(key.len(), 32);
+        assert!(key.is_ascii());
     }
 
     #[test]


### PR DESCRIPTION
## Spec

Implements BENCH-T3 from Accepted Spec 0002 (`specs/0002-baseline-benchmark/`). Tracks #8 and continues M0 after #11.

## What this adds

- server-layer mode in `hkvbench` while preserving existing storage configs
- existing public Tonic/Tokio RPC path only; no production server optimization
- deterministic server dataset preload through public SET RPC
- accepted concurrency sweep: 1 / 8 / 32
- accepted primary dataset sweep: 1k / 10k / 50k at 16B keys / 64B values
- payload sensitivity cells: 16B/256B and 32B/1KiB at 10k keys, concurrency 8
- GET / SET / DELETE / 80-20 read-write workloads
- 5-second target measured window per server workload cell
- separate `rpc_failures` and `runtime_failures`
- `attempted_operations` in addition to successful `measured_operations`
- reproducible `benchmarks/configs/baseline-server.json`
- documented server + benchmark commands

## Correctness / baseline safeguards

- server implementation is not changed
- current per-request server logging remains enabled and is explicitly documented as part of the prototype baseline
- DELETE targets a guaranteed-missing key so cardinality stays stable across cells
- benchmark keys/workload selection remain deterministic from the explicit seed
- results remain labeled non-authoritative single-node prototype measurements
- M1 storage/Crossbeam work remains blocked until M0 verification is complete

## Requirements covered

- REQ-BENCH-001 — all four required workloads
- REQ-BENCH-002 — server concurrency 1/8/32 and required cardinalities
- REQ-BENCH-003 — throughput, p50/p95/p99, operation counts
- REQ-BENCH-004 — workload/environment metadata retained
- REQ-BENCH-008 — checked-in config and documented commands
- REQ-BENCH-009 — explicit prototype/non-distributed labeling
- REQ-BENCH-010 — deterministic dataset and per-worker operation selection

## Still required for M0

- BENCH-T4 — remaining memory/accounting evidence where practical
- BENCH-T6 — immutable repeated full baseline capture
- BENCH-T7 — M0 summary and verification handoff
