### PR TITLE
bench: add M0 memory accounting evidence

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,3 +26,8 @@ jobs:
           cargo run --bin hkvbench -- \
             --config benchmarks/configs/smoke-storage.json \
             --output target/hkvbench-smoke.json
+      - name: M0 memory accounting smoke
+        run: |
+          cargo run --bin hkvmem -- \
+            --config benchmarks/configs/smoke-storage.json \
+            --output target/hkvmem-smoke.json

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,8 +26,15 @@ jobs:
           cargo run --bin hkvbench -- \
             --config benchmarks/configs/smoke-storage.json \
             --output target/hkvbench-smoke.json
-      - name: M0 memory accounting smoke
+      - name: M0 storage memory accounting smoke
         run: |
           cargo run --bin hkvmem -- \
             --config benchmarks/configs/smoke-storage.json \
-            --output target/hkvmem-smoke.json
+            --output target/hkvmem-storage-smoke.json
+      - name: M0 server memory accounting smoke
+        run: |
+          cargo build --bin homekv --bin hkvmem
+          target/debug/hkvmem \
+            --config benchmarks/configs/smoke-server.json \
+            --homekv-bin target/debug/homekv \
+            --output target/hkvmem-server-smoke.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ path = "src/bin/hkvctl.rs"
 [[bin]]
 name = "hkvbench"
 path = "src/bin/hkvbench.rs"
+
+[[bin]]
+name = "hkvmem"
+path = "src/bin/hkvmem.rs"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,11 +9,11 @@ Implemented:
 - BENCH-T1 — deterministic config/result schema and percentile helpers
 - BENCH-T2 — storage-only `BTreeStore` + `Mvcc` baseline
 - BENCH-T3 — existing Tonic/Tokio server/RPC baseline with client concurrency 1/8/32
+- BENCH-T4 — low-intrusion process RSS / approximate bytes-per-key accounting
 - BENCH-T5 — bounded CI smoke mode
 
 Still required before Spec 0002 can become Verified:
 
-- BENCH-T4 — any additional memory/accounting metrics that are practical
 - BENCH-T6 — immutable full prototype result capture
 - BENCH-T7 — baseline analysis/summary
 
@@ -74,9 +74,60 @@ The harness preloads deterministic data through the public SET RPC before measur
 
 RPC failures and Tokio task/runtime failures are reported separately. `measured_operations` counts successful measured RPCs, while `attempted_operations` includes measured RPC attempts that returned an RPC failure. A worker task failure is reported in `runtime_failures`.
 
-The prototype server's existing per-request logging remains enabled. BENCH-T3 must preserve the server path rather than optimize it, so those costs are intentionally part of this historical baseline. The `process_rss_bytes` value in a server-layer result describes the `hkvbench` client process; server-process memory evidence belongs to BENCH-T4.
+The prototype server's existing per-request logging remains enabled. BENCH-T3 must preserve the server path rather than optimize it, so those costs are intentionally part of this historical baseline. The `process_rss_bytes` value in a server-layer result describes the `hkvbench` client process; server-process memory is measured separately by BENCH-T4.
 
 Repeat the full server run at least three times on the same controlled host and retain every run.
+
+## BENCH-T4 memory accounting
+
+`hkvmem` is a companion measurement probe. It deliberately uses process RSS rather than adding allocator hooks to the production server. Its output is evidence for memory scaling, not an exact heap-allocation profile.
+
+### Storage memory matrix
+
+```bash
+cargo run --release --bin hkvmem -- \
+  --config benchmarks/configs/baseline-storage.json \
+  --output benchmarks/results/m0/storage-memory.json
+```
+
+Each storage cell runs in a fresh `hkvmem` worker process. The worker samples its RSS before constructing the dataset and after the populated `Mvcc<BTreeStore>` is resident. This avoids carrying the allocator high-water mark from a larger preceding dataset into a smaller one.
+
+The result includes:
+
+- RSS before population;
+- RSS after population;
+- signed RSS delta;
+- approximate RSS bytes/key when the observed delta is positive;
+- logical key+value payload bytes;
+- RSS-delta / logical-payload ratio.
+
+Temporary deterministic key/value generation and allocator retention can affect the RSS delta. The probe preserves the observed value rather than fabricating an exact allocation number.
+
+### Server-process memory matrix
+
+Build the probe and server first so `hkvmem` can launch a fresh historical HomeKV server for every unique dataset:
+
+```bash
+cargo build --release --bin homekv --bin hkvmem
+
+target/release/hkvmem \
+  --config benchmarks/configs/baseline-server.json \
+  --homekv-bin target/release/homekv \
+  --output benchmarks/results/m0/server-memory.json
+```
+
+For every unique `(key_size, value_size, dataset_cardinality)` in the accepted server matrix, `hkvmem`:
+
+1. starts a fresh unmodified HomeKV Tonic/Tokio process on temporary loopback ports;
+2. waits for the public RPC endpoint to become ready;
+3. samples server-process RSS;
+4. preloads the deterministic dataset through the public SET RPC;
+5. samples server-process RSS again;
+6. terminates the isolated server before moving to the next dataset.
+
+Concurrency variants are intentionally deduplicated for this probe because they share the same resident dataset. Server stdout/stderr are redirected only so the prototype's historical per-request `println!` output cannot fill the measurement driver's pipe; the server implementation itself is not modified.
+
+On hosts without Linux `/proc/<pid>/status`, RSS fields are reported as `null` rather than guessed. Allocations/op remain deferred under REQ-BENCH-005 because adding a reliable low-intrusion allocator profiler is not necessary for the M0 acceptance gate.
 
 ## What is measured
 
@@ -101,4 +152,6 @@ Every result bundle is labeled:
 
 M0 is a single-node prototype baseline, not a distributed or strong-consistency benchmark. Public comparative HomeKV claims require the later distributed correctness and benchmark specs.
 
-The result includes the git SHA, Rust version, OS/kernel, CPU, logical CPU count, host memory where available, benchmark-process RSS where available, workload parameters, attempted/successful operation counts, throughput, p50/p95/p99 latency, and failure counters.
+The latency/throughput bundle includes the git SHA, Rust version, OS/kernel, CPU, logical CPU count, host memory where available, benchmark-process RSS where available, workload parameters, attempted/successful operation counts, throughput, p50/p95/p99 latency, and failure counters.
+
+The BENCH-T4 bundle separately records isolated storage/server RSS deltas and approximate bytes/key with explicit measurement limitations.

--- a/benchmarks/configs/smoke-server.json
+++ b/benchmarks/configs/smoke-server.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "mode": "smoke",
+  "layer": "server",
+  "seed": 42,
+  "workloads": ["get"],
+  "warmup_operations": 1,
+  "server": {
+    "endpoint": "http://127.0.0.1:20001",
+    "duration_ms": 100,
+    "preload_batch_size": 64,
+    "cases": [
+      { "key_size": 16, "value_size": 64, "dataset_cardinality": 64, "concurrency": 1 }
+    ]
+  }
+}

--- a/src/bin/hkvmem.rs
+++ b/src/bin/hkvmem.rs
@@ -1,0 +1,614 @@
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use homekv::storage::{BTreeStore, Mvcc, Store};
+use serde_derive::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::net::{TcpListener, UdpSocket};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tonic::transport::Channel;
+
+use homekv_service::home_kv_service_client::HomeKvServiceClient;
+use homekv_service::{Record, SetRequest};
+
+mod homekv_service {
+    tonic::include_proto!("homekv_service");
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "hkvmem",
+    about = "Low-intrusion HomeKV M0 process/RSS memory accounting probe"
+)]
+struct Args {
+    /// Existing hkvbench JSON configuration. Storage/server dimensions are reused.
+    #[arg(long)]
+    config: PathBuf,
+
+    /// Optional file for the JSON result bundle.
+    #[arg(long)]
+    output: Option<PathBuf>,
+
+    /// Path to a pre-built HomeKV server binary for server-layer memory probes.
+    #[arg(long)]
+    homekv_bin: Option<PathBuf>,
+
+    /// Settle interval before taking RSS samples.
+    #[arg(long, default_value_t = 250)]
+    settle_ms: u64,
+
+    /// Internal isolated storage worker case: key_size,value_size,cardinality.
+    #[arg(long, hide = true)]
+    storage_worker: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PayloadProfile {
+    key_size: usize,
+    value_size: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+struct ServerCase {
+    key_size: usize,
+    value_size: usize,
+    dataset_cardinality: usize,
+    concurrency: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ServerConfig {
+    #[serde(default = "default_preload_batch_size")]
+    preload_batch_size: usize,
+    cases: Vec<ServerCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BenchConfig {
+    schema_version: u32,
+    mode: String,
+    #[serde(default = "default_layer")]
+    layer: String,
+    seed: u64,
+    #[serde(default)]
+    profiles: Vec<PayloadProfile>,
+    #[serde(default)]
+    dataset_cardinalities: Vec<usize>,
+    server: Option<ServerConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MemoryMeasurement {
+    layer: String,
+    target: String,
+    target_pid: u32,
+    key_size: usize,
+    value_size: usize,
+    dataset_cardinality: usize,
+    logical_payload_bytes: u64,
+    rss_before_bytes: Option<u64>,
+    rss_after_population_bytes: Option<u64>,
+    rss_delta_bytes: Option<i64>,
+    rss_bytes_per_key: Option<f64>,
+    rss_over_logical_payload: Option<f64>,
+    notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryBundle {
+    schema_version: u32,
+    mode: String,
+    generated_at_unix_ms: u64,
+    authoritative_performance_result: bool,
+    homekv_git_sha: String,
+    rustc_version: String,
+    os: String,
+    kernel: String,
+    measurements: Vec<MemoryMeasurement>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let config_text = fs::read_to_string(&args.config)
+        .with_context(|| format!("failed to read {}", args.config.display()))?;
+    let config: BenchConfig = serde_json::from_str(&config_text)
+        .with_context(|| format!("invalid benchmark config {}", args.config.display()))?;
+    validate_config(&config)?;
+
+    if let Some(worker) = &args.storage_worker {
+        let (key_size, value_size, dataset_cardinality) = parse_storage_worker(worker)?;
+        let measurement = measure_storage_case(
+            config.seed,
+            key_size,
+            value_size,
+            dataset_cardinality,
+            args.settle_ms,
+        )
+        .await?;
+        println!("{}", serde_json::to_string(&measurement)?);
+        return Ok(());
+    }
+
+    let measurements = match config.layer.as_str() {
+        "storage" => run_storage_matrix(&args, &config)?,
+        "server" => run_server_matrix(&args, &config).await?,
+        _ => unreachable!("validated layer"),
+    };
+
+    let bundle = MemoryBundle {
+        schema_version: 1,
+        mode: config.mode,
+        generated_at_unix_ms: unix_ms(),
+        authoritative_performance_result: false,
+        homekv_git_sha: command_output("git", &["rev-parse", "HEAD"])
+            .or_else(|| std::env::var("GITHUB_SHA").ok())
+            .unwrap_or_else(|| "unknown".to_string()),
+        rustc_version: command_output("rustc", &["--version"])
+            .unwrap_or_else(|| "unknown".to_string()),
+        os: std::env::consts::OS.to_string(),
+        kernel: command_output("uname", &["-r"]).unwrap_or_else(|| "unknown".to_string()),
+        measurements,
+    };
+
+    let encoded = serde_json::to_string_pretty(&bundle)?;
+    if let Some(path) = args.output {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        fs::write(&path, &encoded)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    println!("{encoded}");
+    Ok(())
+}
+
+fn default_layer() -> String {
+    "storage".to_string()
+}
+
+fn default_preload_batch_size() -> usize {
+    8192
+}
+
+fn validate_config(config: &BenchConfig) -> Result<()> {
+    if config.schema_version != 1 {
+        bail!("unsupported config schema_version {}", config.schema_version);
+    }
+    if config.mode != "smoke" && config.mode != "baseline" {
+        bail!("mode must be 'smoke' or 'baseline'");
+    }
+    match config.layer.as_str() {
+        "storage" => {
+            if config.profiles.is_empty() {
+                bail!("storage profiles must not be empty");
+            }
+            if config.dataset_cardinalities.is_empty()
+                || config.dataset_cardinalities.iter().any(|&n| n == 0)
+            {
+                bail!("storage dataset_cardinalities must contain positive values");
+            }
+        }
+        "server" => {
+            let server = config
+                .server
+                .as_ref()
+                .context("server configuration is required for server memory probes")?;
+            if server.preload_batch_size == 0 || server.cases.is_empty() {
+                bail!("server preload_batch_size and cases must be non-empty/positive");
+            }
+        }
+        other => bail!("unsupported benchmark layer '{other}'"),
+    }
+    Ok(())
+}
+
+fn run_storage_matrix(args: &Args, config: &BenchConfig) -> Result<Vec<MemoryMeasurement>> {
+    let exe = std::env::current_exe().context("failed to locate hkvmem executable")?;
+    let mut measurements = Vec::new();
+
+    for profile in &config.profiles {
+        for &dataset_cardinality in &config.dataset_cardinalities {
+            let worker = format!(
+                "{},{},{}",
+                profile.key_size, profile.value_size, dataset_cardinality
+            );
+            let output = Command::new(&exe)
+                .arg("--config")
+                .arg(&args.config)
+                .arg("--settle-ms")
+                .arg(args.settle_ms.to_string())
+                .arg("--storage-worker")
+                .arg(&worker)
+                .output()
+                .with_context(|| format!("failed to launch isolated storage worker {worker}"))?;
+            if !output.status.success() {
+                bail!(
+                    "storage worker {worker} failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            let measurement: MemoryMeasurement = serde_json::from_slice(&output.stdout)
+                .with_context(|| format!("storage worker {worker} emitted invalid JSON"))?;
+            measurements.push(measurement);
+        }
+    }
+    Ok(measurements)
+}
+
+async fn measure_storage_case(
+    seed: u64,
+    key_size: usize,
+    value_size: usize,
+    dataset_cardinality: usize,
+    settle_ms: u64,
+) -> Result<MemoryMeasurement> {
+    let pid = std::process::id();
+    tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+    let before = process_rss_bytes(pid);
+
+    let store = Mvcc::new(BTreeStore::new());
+    let mut write_txn = store.write().await;
+    {
+        let inner = write_txn.get_mut();
+        for i in 0..dataset_cardinality {
+            let key = deterministic_bytes(seed, i as u64, key_size);
+            let value = deterministic_bytes(
+                seed ^ 0xa5a5_a5a5_a5a5_a5a5,
+                i as u64,
+                value_size,
+            );
+            inner.set(&key, value)?;
+        }
+    }
+    write_txn.commit().await;
+
+    tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+    std::hint::black_box(&store);
+    let after = process_rss_bytes(pid);
+    Ok(build_measurement(
+        "storage",
+        "isolated hkvmem process containing Mvcc<BTreeStore>",
+        pid,
+        key_size,
+        value_size,
+        dataset_cardinality,
+        before,
+        after,
+        vec![
+            "each storage cell runs in a fresh process to reduce allocator high-water contamination between dataset sizes".to_string(),
+            "RSS delta is process-level evidence, not exact heap allocation accounting".to_string(),
+            "temporary deterministic key/value generation can affect allocator retention; bytes/key is therefore approximate".to_string(),
+        ],
+    ))
+}
+
+async fn run_server_matrix(args: &Args, config: &BenchConfig) -> Result<Vec<MemoryMeasurement>> {
+    let server = config
+        .server
+        .as_ref()
+        .context("validated server configuration")?;
+    let homekv_bin = resolve_homekv_bin(args)?;
+
+    let unique_cases = server
+        .cases
+        .iter()
+        .map(|case| (case.key_size, case.value_size, case.dataset_cardinality))
+        .collect::<BTreeSet<_>>();
+
+    let mut measurements = Vec::new();
+    for (key_size, value_size, dataset_cardinality) in unique_cases {
+        measurements.push(
+            measure_server_case(
+                &homekv_bin,
+                config.seed,
+                key_size,
+                value_size,
+                dataset_cardinality,
+                server.preload_batch_size,
+                args.settle_ms,
+            )
+            .await?,
+        );
+    }
+    Ok(measurements)
+}
+
+async fn measure_server_case(
+    homekv_bin: &Path,
+    seed: u64,
+    key_size: usize,
+    value_size: usize,
+    dataset_cardinality: usize,
+    preload_batch_size: usize,
+    settle_ms: u64,
+) -> Result<MemoryMeasurement> {
+    let port = free_tcp_port()?;
+    let gossip_port = free_udp_port()?;
+    let endpoint = format!("http://127.0.0.1:{port}");
+
+    let mut child = Command::new(homekv_bin)
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--public_host")
+        .arg("127.0.0.1")
+        .arg("--gossip_port")
+        .arg(gossip_port.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to start {}", homekv_bin.display()))?;
+    let pid = child.id();
+
+    let result = async {
+        let mut client = wait_for_server(&endpoint, &mut child).await?;
+        tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+        let before = process_rss_bytes(pid);
+
+        preload_server_dataset(
+            &mut client,
+            seed,
+            key_size,
+            value_size,
+            dataset_cardinality,
+            preload_batch_size,
+        )
+        .await?;
+
+        tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+        let after = process_rss_bytes(pid);
+        Ok::<_, anyhow::Error>(build_measurement(
+            "server",
+            "fresh unmodified HomeKV Tonic/Tokio server process",
+            pid,
+            key_size,
+            value_size,
+            dataset_cardinality,
+            before,
+            after,
+            vec![
+                "each server memory cell starts a fresh HomeKV process; client concurrency is intentionally deduplicated because it does not change the preloaded dataset".to_string(),
+                "server stdout/stderr are suppressed only to prevent historical per-request logging from contaminating the measurement driver; server code is unchanged".to_string(),
+                "RSS delta includes runtime/storage allocator behavior and is not exact heap allocation accounting".to_string(),
+            ],
+        ))
+    }
+    .await;
+
+    let _ = child.kill();
+    let _ = child.wait();
+    result
+}
+
+async fn wait_for_server(
+    endpoint: &str,
+    child: &mut std::process::Child,
+) -> Result<HomeKvServiceClient<Channel>> {
+    let mut last_error = None;
+    for _ in 0..80 {
+        if let Some(status) = child.try_wait().context("failed to inspect HomeKV child")? {
+            bail!("HomeKV server exited before becoming ready: {status}");
+        }
+        match HomeKvServiceClient::connect(endpoint.to_string()).await {
+            Ok(client) => return Ok(client),
+            Err(error) => last_error = Some(error),
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    bail!(
+        "HomeKV server did not become ready at {endpoint}: {:?}",
+        last_error
+    )
+}
+
+async fn preload_server_dataset(
+    client: &mut HomeKvServiceClient<Channel>,
+    seed: u64,
+    key_size: usize,
+    value_size: usize,
+    dataset_cardinality: usize,
+    batch_size: usize,
+) -> Result<()> {
+    for start in (0..dataset_cardinality).step_by(batch_size) {
+        let end = (start + batch_size).min(dataset_cardinality);
+        let records = (start..end)
+            .map(|idx| Record {
+                key: deterministic_key(seed, idx as u64, key_size),
+                value: Some(deterministic_bytes(
+                    seed ^ 0xa5a5_a5a5_a5a5_a5a5,
+                    idx as u64,
+                    value_size,
+                )),
+            })
+            .collect();
+        let response = client
+            .set(SetRequest { records })
+            .await
+            .context("server memory preload SET RPC failed")?
+            .into_inner();
+        if !response.succ {
+            bail!("server memory preload SET returned succ=false");
+        }
+    }
+    Ok(())
+}
+
+fn resolve_homekv_bin(args: &Args) -> Result<PathBuf> {
+    if let Some(path) = &args.homekv_bin {
+        if path.exists() {
+            return Ok(path.clone());
+        }
+        bail!("--homekv-bin does not exist: {}", path.display());
+    }
+
+    let current = std::env::current_exe().context("failed to locate hkvmem executable")?;
+    #[cfg(windows)]
+    let candidate = current.with_file_name("homekv.exe");
+    #[cfg(not(windows))]
+    let candidate = current.with_file_name("homekv");
+    if !candidate.exists() {
+        bail!(
+            "HomeKV server binary not found at {}. Build both binaries first or pass --homekv-bin.",
+            candidate.display()
+        );
+    }
+    Ok(candidate)
+}
+
+fn build_measurement(
+    layer: &str,
+    target: &str,
+    target_pid: u32,
+    key_size: usize,
+    value_size: usize,
+    dataset_cardinality: usize,
+    before: Option<u64>,
+    after: Option<u64>,
+    notes: Vec<String>,
+) -> MemoryMeasurement {
+    let logical_payload_bytes = logical_payload_bytes(key_size, value_size, dataset_cardinality);
+    let delta = rss_delta(before, after);
+    let positive_delta = delta.filter(|value| *value > 0).map(|value| value as f64);
+    let rss_bytes_per_key = positive_delta.map(|value| value / dataset_cardinality as f64);
+    let rss_over_logical_payload = positive_delta.and_then(|value| {
+        (logical_payload_bytes > 0).then_some(value / logical_payload_bytes as f64)
+    });
+
+    MemoryMeasurement {
+        layer: layer.to_string(),
+        target: target.to_string(),
+        target_pid,
+        key_size,
+        value_size,
+        dataset_cardinality,
+        logical_payload_bytes,
+        rss_before_bytes: before,
+        rss_after_population_bytes: after,
+        rss_delta_bytes: delta,
+        rss_bytes_per_key,
+        rss_over_logical_payload,
+        notes,
+    }
+}
+
+fn logical_payload_bytes(key_size: usize, value_size: usize, count: usize) -> u64 {
+    (key_size as u64)
+        .saturating_add(value_size as u64)
+        .saturating_mul(count as u64)
+}
+
+fn rss_delta(before: Option<u64>, after: Option<u64>) -> Option<i64> {
+    let before = before? as i128;
+    let after = after? as i128;
+    i64::try_from(after - before).ok()
+}
+
+fn process_rss_bytes(pid: u32) -> Option<u64> {
+    linux_kib_field(&PathBuf::from(format!("/proc/{pid}/status")), "VmRSS")
+}
+
+fn linux_kib_field(path: &Path, key: &str) -> Option<u64> {
+    let text = fs::read_to_string(path).ok()?;
+    let value = text.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        (name.trim() == key).then(|| value.trim().to_string())
+    })?;
+    let number = value.split_whitespace().next()?.parse::<u64>().ok()?;
+    number.checked_mul(1024)
+}
+
+fn free_tcp_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn free_udp_port() -> Result<u16> {
+    let socket = UdpSocket::bind("127.0.0.1:0")?;
+    Ok(socket.local_addr()?.port())
+}
+
+fn parse_storage_worker(value: &str) -> Result<(usize, usize, usize)> {
+    let parts = value
+        .split(',')
+        .map(str::parse::<usize>)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("storage worker must be key_size,value_size,cardinality")?;
+    if parts.len() != 3 || parts.iter().any(|value| *value == 0) {
+        bail!("storage worker must contain three positive integers");
+    }
+    Ok((parts[0], parts[1], parts[2]))
+}
+
+fn deterministic_key(seed: u64, ordinal: u64, len: usize) -> String {
+    String::from_utf8(deterministic_bytes(seed, ordinal, len))
+        .expect("deterministic benchmark keys are ASCII hex")
+}
+
+fn deterministic_bytes(seed: u64, ordinal: u64, len: usize) -> Vec<u8> {
+    let mut result = Vec::with_capacity(len);
+    let mut block = 0_u64;
+    while result.len() < len {
+        let mixed = splitmix64(
+            seed ^ ordinal.wrapping_mul(0x9e37_79b9_7f4a_7c15) ^ block.rotate_left(29),
+        );
+        let chunk = format!("{mixed:016x}");
+        result.extend_from_slice(chunk.as_bytes());
+        block = block.wrapping_add(1);
+    }
+    result.truncate(len);
+    result
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
+}
+
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u64::MAX as u128) as u64
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    Some(value.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_case_parser_requires_three_positive_dimensions() {
+        assert_eq!(parse_storage_worker("16,64,1000").unwrap(), (16, 64, 1000));
+        assert!(parse_storage_worker("16,64").is_err());
+        assert!(parse_storage_worker("16,0,1000").is_err());
+    }
+
+    #[test]
+    fn logical_payload_is_key_plus_value_times_count() {
+        assert_eq!(logical_payload_bytes(16, 64, 1000), 80_000);
+    }
+
+    #[test]
+    fn rss_delta_preserves_negative_measurements_instead_of_fabricating_zero() {
+        assert_eq!(rss_delta(Some(4096), Some(8192)), Some(4096));
+        assert_eq!(rss_delta(Some(8192), Some(4096)), Some(-4096));
+        assert_eq!(rss_delta(None, Some(4096)), None);
+    }
+}


### PR DESCRIPTION
## Spec

Implements BENCH-T4 from Accepted Spec 0002 (`specs/0002-baseline-benchmark/`). Tracks #8 and continues M0 after #15.

## What this adds

- `hkvmem` companion memory-accounting binary
- isolated storage-process RSS measurement per dataset cell
- fresh unmodified HomeKV server process per unique server dataset
- RSS before/after deterministic population
- signed RSS delta
- approximate RSS bytes/key when the observed delta is positive
- logical key+value payload bytes and RSS/payload ratio
- Linux `/proc/<pid>/status` collection with null-on-unsupported behavior
- bounded CI storage-memory smoke run
- reproducible commands for the full storage and server memory matrices

## Measurement safeguards

### Storage

Each storage case is executed in a fresh `hkvmem` subprocess so allocator high-water state from an earlier/larger case does not contaminate later cases.

### Server

Each unique `(key_size, value_size, dataset_cardinality)` gets a fresh historical HomeKV Tonic/Tokio server process. Data is loaded only through the existing public SET RPC. Concurrency variants are deduplicated because they do not change the resident dataset.

The server implementation is not changed. Its stdout/stderr are suppressed by the measurement driver only so historical per-request logging cannot fill a child-process output pipe.

## Semantics / limitations

RSS is deliberately treated as low-intrusion process-level evidence, not exact heap allocation accounting. Temporary deterministic value generation, allocator retention, runtime memory, page accounting, and measurement granularity can affect deltas. Negative/unknown observations are preserved rather than converted into fabricated positive memory numbers.

Allocations/op remain deferred under REQ-BENCH-005 because a reliable allocator profiler is optional and is not required for the M0 acceptance gate.

## Requirements covered

- REQ-BENCH-004 — memory evidence retains exact git/toolchain/OS/kernel metadata
- REQ-BENCH-005 — process memory and approximate memory/key where practical, with limitations documented
- REQ-BENCH-008 — checked-in executable and reproducible commands
- REQ-BENCH-009 — memory bundles remain explicitly non-authoritative M0 prototype evidence
- REQ-BENCH-011 — bounded CI smoke validates the probe without running the full matrix

## Still required for M0

- BENCH-T6 — immutable repeated full pre-M1 baseline capture
- BENCH-T7 — analysis, requirement verification matrix, and Spec 0002 verification handoff

M1/#9 remains blocked until Spec 0002 is Verified.