### PR TITLE
bench: capture immutable M0 baseline evidence

### DIFF
--- a/.github/workflows/m0-baseline-capture.yml
+++ b/.github/workflows/m0-baseline-capture.yml
@@ -3,6 +3,8 @@ name: M0 Baseline Capture
 on:
   push:
     branches: ["spec-0002-bench-t6-capture"]
+  pull_request:
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -76,15 +78,14 @@ jobs:
       - name: Validate exact SHA appears in result bundles
         run: |
           python3 - <<'PY'
-          import json, pathlib, sys
+          import json, pathlib
           expected = "e64b8d268858b58edfb2f6e83d9edfc3ad5b3b39"
           files = sorted(pathlib.Path("benchmarks/results/m0").glob("*.json"))
           if len(files) != 8:
               raise SystemExit(f"expected 8 result bundles, found {len(files)}")
           for path in files:
               data = json.loads(path.read_text())
-              text = json.dumps(data)
-              if expected not in text:
+              if expected not in json.dumps(data):
                   raise SystemExit(f"{path}: exact baseline SHA missing")
           print(f"validated {len(files)} result bundles at {expected}")
           PY

--- a/.github/workflows/m0-baseline-capture.yml
+++ b/.github/workflows/m0-baseline-capture.yml
@@ -1,0 +1,99 @@
+name: M0 Baseline Capture
+
+on:
+  push:
+    branches: ["spec-0002-bench-t6-capture"]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  BASELINE_SHA: e64b8d268858b58edfb2f6e83d9edfc3ad5b3b39
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+      - name: Checkout exact pre-M1 baseline
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BASELINE_SHA }}
+      - name: Verify immutable source revision
+        run: |
+          test "$(git rev-parse HEAD)" = "$BASELINE_SHA"
+          test -z "$(git status --porcelain)"
+      - name: Build release benchmark binaries
+        run: cargo build --release --bin homekv --bin hkvbench --bin hkvmem
+      - name: Capture repeated storage baseline
+        run: |
+          mkdir -p benchmarks/results/m0
+          for run in 1 2 3; do
+            target/release/hkvbench \
+              --config benchmarks/configs/baseline-storage.json \
+              --output "benchmarks/results/m0/storage-run-${run}.json"
+          done
+      - name: Capture repeated server baseline
+        run: |
+          target/release/homekv \
+            --host 127.0.0.1 \
+            --port 20001 \
+            --public_host 127.0.0.1 \
+            --gossip_port 20002 \
+            > target/m0-homekv-server.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+          for attempt in $(seq 1 60); do
+            if target/release/hkvbench \
+              --config benchmarks/configs/smoke-server.json \
+              --output target/server-ready-smoke.json >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              echo "server did not become ready" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          for run in 1 2 3; do
+            target/release/hkvbench \
+              --config benchmarks/configs/baseline-server.json \
+              --output "benchmarks/results/m0/server-run-${run}.json"
+          done
+      - name: Capture memory evidence
+        run: |
+          target/release/hkvmem \
+            --config benchmarks/configs/baseline-storage.json \
+            --output benchmarks/results/m0/storage-memory.json
+          target/release/hkvmem \
+            --config benchmarks/configs/baseline-server.json \
+            --homekv-bin target/release/homekv \
+            --output benchmarks/results/m0/server-memory.json
+      - name: Validate exact SHA appears in result bundles
+        run: |
+          python3 - <<'PY'
+          import json, pathlib, sys
+          expected = "e64b8d268858b58edfb2f6e83d9edfc3ad5b3b39"
+          files = sorted(pathlib.Path("benchmarks/results/m0").glob("*.json"))
+          if len(files) != 8:
+              raise SystemExit(f"expected 8 result bundles, found {len(files)}")
+          for path in files:
+              data = json.loads(path.read_text())
+              text = json.dumps(data)
+              if expected not in text:
+                  raise SystemExit(f"{path}: exact baseline SHA missing")
+          print(f"validated {len(files)} result bundles at {expected}")
+          PY
+      - name: Upload immutable M0 result bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: homekv-m0-baseline-${{ env.BASELINE_SHA }}
+          path: |
+            benchmarks/results/m0/*.json
+            target/m0-homekv-server.log
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/m0-baseline-capture.yml
+++ b/.github/workflows/m0-baseline-capture.yml
@@ -31,63 +31,109 @@ jobs:
           test -z "$(git status --porcelain)"
       - name: Build release benchmark binaries
         run: cargo build --release --bin homekv --bin hkvbench --bin hkvmem
+      - name: Prepare capture-only server preload config
+        run: |
+          python3 - <<'PY'
+          import json, pathlib
+          source = pathlib.Path("benchmarks/configs/baseline-server.json")
+          target = pathlib.Path("target/m0-baseline-server-capture.json")
+          data = json.loads(source.read_text())
+          # Preload is outside the measured window. The accepted 8,192-record
+          # batch exceeds Tonic's default 4 MiB message limit for the 1 KiB
+          # payload-sensitivity cell, so BENCH-T6 uses a smaller capture-only
+          # batch without changing any measured workload dimensions/semantics.
+          data["server"]["preload_batch_size"] = 1024
+          target.write_text(json.dumps(data, indent=2) + "\n")
+          print(f"capture preload_batch_size={data['server']['preload_batch_size']}")
+          PY
       - name: Capture repeated storage baseline
         run: |
           mkdir -p benchmarks/results/m0
           for run in 1 2 3; do
             target/release/hkvbench \
               --config benchmarks/configs/baseline-storage.json \
-              --output "benchmarks/results/m0/storage-run-${run}.json"
+              --output "benchmarks/results/m0/storage-run-${run}.json" \
+              >/dev/null
           done
       - name: Capture repeated server baseline
         run: |
-          target/release/homekv \
-            --host 127.0.0.1 \
-            --port 20001 \
-            --public_host 127.0.0.1 \
-            --gossip_port 20002 \
-            > target/m0-homekv-server.log 2>&1 &
-          server_pid=$!
-          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
-          for attempt in $(seq 1 60); do
-            if target/release/hkvbench \
-              --config benchmarks/configs/smoke-server.json \
-              --output target/server-ready-smoke.json >/dev/null 2>&1; then
-              break
-            fi
-            if [ "$attempt" -eq 60 ]; then
-              echo "server did not become ready" >&2
-              exit 1
-            fi
-            sleep 1
-          done
           for run in 1 2 3; do
+            log="target/m0-homekv-server-run-${run}.log"
+            target/release/homekv \
+              --host 127.0.0.1 \
+              --port 20001 \
+              --public_host 127.0.0.1 \
+              --gossip_port 20002 \
+              > "$log" 2>&1 &
+            server_pid=$!
+
+            cleanup_server() {
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            }
+            trap cleanup_server EXIT
+
+            for attempt in $(seq 1 60); do
+              if target/release/hkvbench \
+                --config benchmarks/configs/smoke-server.json \
+                --output target/server-ready-smoke.json >/dev/null 2>&1; then
+                break
+              fi
+              if ! kill -0 "$server_pid" 2>/dev/null; then
+                echo "server exited before becoming ready; tail follows" >&2
+                tail -100 "$log" >&2 || true
+                exit 1
+              fi
+              if [ "$attempt" -eq 60 ]; then
+                echo "server did not become ready; tail follows" >&2
+                tail -100 "$log" >&2 || true
+                exit 1
+              fi
+              sleep 1
+            done
+
             target/release/hkvbench \
-              --config benchmarks/configs/baseline-server.json \
-              --output "benchmarks/results/m0/server-run-${run}.json"
+              --config target/m0-baseline-server-capture.json \
+              --output "benchmarks/results/m0/server-run-${run}.json" \
+              >/dev/null
+
+            cleanup_server
+            trap - EXIT
+            gzip -9 "$log"
+            sleep 1
           done
       - name: Capture memory evidence
         run: |
           target/release/hkvmem \
             --config benchmarks/configs/baseline-storage.json \
-            --output benchmarks/results/m0/storage-memory.json
+            --output benchmarks/results/m0/storage-memory.json \
+            >/dev/null
           target/release/hkvmem \
-            --config benchmarks/configs/baseline-server.json \
+            --config target/m0-baseline-server-capture.json \
             --homekv-bin target/release/homekv \
-            --output benchmarks/results/m0/server-memory.json
-      - name: Validate exact SHA appears in result bundles
+            --output benchmarks/results/m0/server-memory.json \
+            >/dev/null
+      - name: Validate captured result contract
         run: |
           python3 - <<'PY'
           import json, pathlib
           expected = "e64b8d268858b58edfb2f6e83d9edfc3ad5b3b39"
-          files = sorted(pathlib.Path("benchmarks/results/m0").glob("*.json"))
+          root = pathlib.Path("benchmarks/results/m0")
+          files = sorted(root.glob("*.json"))
           if len(files) != 8:
               raise SystemExit(f"expected 8 result bundles, found {len(files)}")
           for path in files:
               data = json.loads(path.read_text())
-              if expected not in json.dumps(data):
+              encoded = json.dumps(data)
+              if expected not in encoded:
                   raise SystemExit(f"{path}: exact baseline SHA missing")
-          print(f"validated {len(files)} result bundles at {expected}")
+              if data.get("authoritative_performance_result") is not False:
+                  raise SystemExit(f"{path}: M0 result must remain non-authoritative")
+          for prefix in ("storage-run-", "server-run-"):
+              matched = sorted(root.glob(f"{prefix}*.json"))
+              if len(matched) != 3:
+                  raise SystemExit(f"expected 3 {prefix} repetitions, found {len(matched)}")
+          print(f"validated {len(files)} immutable result bundles at {expected}")
           PY
       - name: Upload immutable M0 result bundle
         uses: actions/upload-artifact@v4
@@ -95,6 +141,7 @@ jobs:
           name: homekv-m0-baseline-${{ env.BASELINE_SHA }}
           path: |
             benchmarks/results/m0/*.json
-            target/m0-homekv-server.log
+            target/m0-baseline-server-capture.json
+            target/m0-homekv-server-run-*.log.gz
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/m0-baseline-capture.yml
+++ b/.github/workflows/m0-baseline-capture.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  BASELINE_SHA: e64b8d268858b58edfb2f6e83d9edfc3ad5b3b39
+  BASELINE_SHA: bc613b74e8c718a7d002f1cacbd8d51cddbf3067
 
 jobs:
   capture:
@@ -31,21 +31,6 @@ jobs:
           test -z "$(git status --porcelain)"
       - name: Build release benchmark binaries
         run: cargo build --release --bin homekv --bin hkvbench --bin hkvmem
-      - name: Prepare capture-only server preload config
-        run: |
-          python3 - <<'PY'
-          import json, pathlib
-          source = pathlib.Path("benchmarks/configs/baseline-server.json")
-          target = pathlib.Path("target/m0-baseline-server-capture.json")
-          data = json.loads(source.read_text())
-          # Preload is outside the measured window. The accepted 8,192-record
-          # batch exceeds Tonic's default 4 MiB message limit for the 1 KiB
-          # payload-sensitivity cell, so BENCH-T6 uses a smaller capture-only
-          # batch without changing any measured workload dimensions/semantics.
-          data["server"]["preload_batch_size"] = 1024
-          target.write_text(json.dumps(data, indent=2) + "\n")
-          print(f"capture preload_batch_size={data['server']['preload_batch_size']}")
-          PY
       - name: Capture repeated storage baseline
         run: |
           mkdir -p benchmarks/results/m0
@@ -93,7 +78,7 @@ jobs:
             done
 
             target/release/hkvbench \
-              --config target/m0-baseline-server-capture.json \
+              --config benchmarks/configs/baseline-server.json \
               --output "benchmarks/results/m0/server-run-${run}.json" \
               >/dev/null
 
@@ -109,7 +94,7 @@ jobs:
             --output benchmarks/results/m0/storage-memory.json \
             >/dev/null
           target/release/hkvmem \
-            --config target/m0-baseline-server-capture.json \
+            --config benchmarks/configs/baseline-server.json \
             --homekv-bin target/release/homekv \
             --output benchmarks/results/m0/server-memory.json \
             >/dev/null
@@ -117,7 +102,7 @@ jobs:
         run: |
           python3 - <<'PY'
           import json, pathlib
-          expected = "e64b8d268858b58edfb2f6e83d9edfc3ad5b3b39"
+          expected = "bc613b74e8c718a7d002f1cacbd8d51cddbf3067"
           root = pathlib.Path("benchmarks/results/m0")
           files = sorted(root.glob("*.json"))
           if len(files) != 8:
@@ -141,7 +126,6 @@ jobs:
           name: homekv-m0-baseline-${{ env.BASELINE_SHA }}
           path: |
             benchmarks/results/m0/*.json
-            target/m0-baseline-server-capture.json
             target/m0-homekv-server-run-*.log.gz
           if-no-files-found: error
           retention-days: 90


### PR DESCRIPTION
## Spec

Implements BENCH-T6 from Accepted Spec 0002 (`specs/0002-baseline-benchmark/`). Tracks #8.

## Scope

Adds a dedicated GitHub Actions capture workflow only. The workflow checks out and verifies exact pre-M1 baseline commit `bc613b74e8c718a7d002f1cacbd8d51cddbf3067`; it does not modify storage, server, consistency, durability, or benchmark semantics.

It captures:
- three full storage baseline repetitions
- three full Tonic/Tokio server baseline repetitions, each with a fresh HomeKV process
- storage and server process-memory evidence
- exact-SHA/non-authoritative validation for every archived JSON result bundle
- one retained artifact containing all raw evidence and server logs

## Corrective prerequisite

The first capture exposed that the accepted 8,192-record preload batch exceeded Tonic's default 4 MiB message limit for the 32-byte key / 1 KiB value payload cell. PR #18 corrected only the checked-in preload batch size to 2,048; preload remains outside the measured window. This PR is now pinned to that merged exact main commit and no longer uses a capture-only config override.

## Requirements / task

- BENCH-T6
- REQ-BENCH-002/003/004/006/007/008/009/012

## Gate

Do not merge unless normal Rust CI and the M0 Baseline Capture workflow both pass and the capture artifact is present. BENCH-T7 and Spec 0002 verification remain separate follow-up work; M1/#9 remains blocked.