### PR TITLE
bench: bound M0 server preload batches

### DIFF
--- a/benchmarks/configs/baseline-server.json
+++ b/benchmarks/configs/baseline-server.json
@@ -8,7 +8,7 @@
   "server": {
     "endpoint": "http://127.0.0.1:20001",
     "duration_ms": 5000,
-    "preload_batch_size": 8192,
+    "preload_batch_size": 2048,
     "cases": [
       { "key_size": 16, "value_size": 64, "dataset_cardinality": 1000, "concurrency": 1 },
       { "key_size": 16, "value_size": 64, "dataset_cardinality": 1000, "concurrency": 8 },


### PR DESCRIPTION
## Spec

Corrective BENCH-T6 prerequisite under Accepted Spec 0002. Tracks #8 and fixes the exact failure observed in PR #17's immutable baseline capture.

## Failure evidence

The accepted 32-byte key / 1 KiB value payload cell failed during preload because `preload_batch_size=8192` encoded an ~8.7 MiB SET request, above Tonic's default 4 MiB decode limit.

## Change

Reduce only the benchmark preload batch size from 8192 to 2048 records. Dataset contents, workload matrix, measured duration, concurrency, production server implementation, MVCC behavior, and measured request semantics are unchanged. Preload remains outside the measured window.

At the largest accepted payload profile, 2048 x (32 + 1024) logical bytes is ~2.06 MiB before protobuf overhead, leaving substantial headroom below the 4 MiB transport limit.

## SDD gate

This is benchmark/support configuration permitted by Spec 0002 design §12; it is not a server performance optimization. After merge, PR #17 must repin `BASELINE_SHA` to this new exact pre-M1 main commit and rerun the full capture. M1/#9 remains blocked.