### PR TITLE
spec: verify M0 baseline and hand off to M1

### DIFF
--- a/.github/workflows/m0-baseline-capture.yml
+++ b/.github/workflows/m0-baseline-capture.yml
@@ -1,10 +1,7 @@
 name: M0 Baseline Capture
 
 on:
-  push:
-    branches: ["spec-0002-bench-t6-capture"]
-  pull_request:
-    branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/m0-verification.yml
+++ b/.github/workflows/m0-verification.yml
@@ -1,0 +1,81 @@
+name: M0 Verification
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "benchmarks/analyze_m0.py"
+      - "specs/0002-baseline-benchmark/**"
+      - ".github/workflows/m0-verification.yml"
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  SOURCE_RUN_ID: "33080513696"
+  ARTIFACT_ID: "9650486609"
+  ARTIFACT_NAME: "homekv-m0-baseline-bc613b74e8c718a7d002f1cacbd8d51cddbf3067"
+  ARTIFACT_DIGEST: "sha256:015faf8d87c8d197457ca9c6fd2f2c8d1ab07dc0bc16a2e62a2517335331680c"
+  BASELINE_SHA: "bc613b74e8c718a7d002f1cacbd8d51cddbf3067"
+
+jobs:
+  verify-retained-evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout BENCH-T7 tooling
+        uses: actions/checkout@v4
+
+      - name: Verify retained artifact identity
+        run: |
+          gh api "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}" \
+            > "$RUNNER_TEMP/m0-artifact.json"
+          python3 - <<'PY'
+          import json, os, pathlib
+
+          data = json.loads((pathlib.Path(os.environ["RUNNER_TEMP"]) / "m0-artifact.json").read_text())
+          expected = {
+              "id": int(os.environ["ARTIFACT_ID"]),
+              "name": os.environ["ARTIFACT_NAME"],
+              "digest": os.environ["ARTIFACT_DIGEST"],
+          }
+          for key, value in expected.items():
+              if data.get(key) != value:
+                  raise SystemExit(f"artifact {key} mismatch: {data.get(key)!r} != {value!r}")
+          if data.get("expired") is not False:
+              raise SystemExit("retained M0 artifact is expired")
+          run = data.get("workflow_run") or {}
+          if int(run.get("id", -1)) != int(os.environ["SOURCE_RUN_ID"]):
+              raise SystemExit(f"artifact run mismatch: {run.get('id')!r}")
+          print("retained M0 artifact identity verified")
+          PY
+
+      - name: Download retained T6 evidence
+        run: |
+          rm -rf target/m0-retained
+          mkdir -p target/m0-retained
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$ARTIFACT_NAME" \
+            --dir target/m0-retained
+
+      - name: Analyze retained M0 results
+        run: |
+          python3 benchmarks/analyze_m0.py \
+            --input target/m0-retained/benchmarks/results/m0 \
+            --output target/m0-analysis.md \
+            --baseline-sha "$BASELINE_SHA"
+          cat target/m0-analysis.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload derived BENCH-T7 report
+        uses: actions/upload-artifact@v4
+        with:
+          name: homekv-m0-analysis-${{ env.BASELINE_SHA }}
+          path: target/m0-analysis.md
+          if-no-files-found: error
+          retention-days: 90

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,20 +2,21 @@
 
 This directory implements Spec 0002 (M0 prototype baseline).
 
-## Current slice
+## M0 status
 
-Implemented:
+Spec 0002 is **Verified** on the BENCH-T7 verification branch pending merge.
+
+Completed:
 
 - BENCH-T1 — deterministic config/result schema and percentile helpers
 - BENCH-T2 — storage-only `BTreeStore` + `Mvcc` baseline
 - BENCH-T3 — existing Tonic/Tokio server/RPC baseline with client concurrency 1/8/32
 - BENCH-T4 — low-intrusion process RSS / approximate bytes-per-key accounting
 - BENCH-T5 — bounded CI smoke mode
+- BENCH-T6 — immutable repeated full prototype capture
+- BENCH-T7 — retained-artifact analysis and verification handoff
 
-Still required before Spec 0002 can become Verified:
-
-- BENCH-T6 — immutable full prototype result capture
-- BENCH-T7 — baseline analysis/summary
+The durable analysis and caveats live in [`specs/0002-baseline-benchmark/m0-analysis.md`](../specs/0002-baseline-benchmark/m0-analysis.md). The exact retained artifact is revalidated by `.github/workflows/m0-verification.yml` and analyzed by `benchmarks/analyze_m0.py`.
 
 No M1 storage optimization belongs in M0.
 
@@ -128,6 +129,31 @@ For every unique `(key_size, value_size, dataset_cardinality)` in the accepted s
 Concurrency variants are intentionally deduplicated for this probe because they share the same resident dataset. Server stdout/stderr are redirected only so the prototype's historical per-request `println!` output cannot fill the measurement driver's pipe; the server implementation itself is not modified.
 
 On hosts without Linux `/proc/<pid>/status`, RSS fields are reported as `null` rather than guessed. Allocations/op remain deferred under REQ-BENCH-005 because adding a reliable low-intrusion allocator profiler is not necessary for the M0 acceptance gate.
+
+## BENCH-T6 retained baseline
+
+The immutable M0 comparison point is:
+
+- baseline SHA: `bc613b74e8c718a7d002f1cacbd8d51cddbf3067`
+- workflow run: `33080513696`
+- artifact id: `9650486609`
+- artifact name: `homekv-m0-baseline-bc613b74e8c718a7d002f1cacbd8d51cddbf3067`
+- digest: `sha256:015faf8d87c8d197457ca9c6fd2f2c8d1ab07dc0bc16a2e62a2517335331680c`
+
+The capture contains three complete storage runs, three complete server runs, storage/server memory evidence, and the historical server logs. It must not be replaced by a later M1 run.
+
+## BENCH-T7 analysis
+
+To analyze the exact retained T6 result bundles rather than recapturing on a different runner:
+
+```bash
+python3 benchmarks/analyze_m0.py \
+  --input <downloaded-artifact>/benchmarks/results/m0 \
+  --output target/m0-analysis.md \
+  --baseline-sha bc613b74e8c718a7d002f1cacbd8d51cddbf3067
+```
+
+The `M0 Verification` GitHub Actions workflow verifies the retained artifact id/name/digest/run identity, downloads that exact artifact, executes the analyzer, and publishes the derived report to the job summary.
 
 ## What is measured
 

--- a/benchmarks/analyze_m0.py
+++ b/benchmarks/analyze_m0.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Summarize immutable HomeKV M0 benchmark bundles for Spec 0002 verification.
+
+The analyzer intentionally reports observations only. It does not infer causes and it does
+not turn M0 into an authoritative distributed-performance result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from statistics import median
+from typing import Any, Iterable
+
+PRIMARY_KEY_SIZE = 16
+PRIMARY_VALUE_SIZE = 64
+PRIMARY_DATASETS = (1_000, 10_000, 50_000)
+PRIMARY_CONCURRENCY = (1, 8, 32)
+WORKLOADS = ("get", "set", "delete", "read80_write20")
+PAYLOAD_CASES = ((16, 64), (16, 256), (32, 1024))
+PAYLOAD_DATASET = 10_000
+PAYLOAD_CONCURRENCY = 8
+EXPECTED_REPETITIONS = 3
+LOW_P99_TAIL_OBSERVATIONS = 5
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze HomeKV M0 benchmark result bundles")
+    parser.add_argument("--input", type=Path, required=True, help="directory containing M0 JSON bundles")
+    parser.add_argument("--output", type=Path, required=True, help="markdown report path")
+    parser.add_argument("--baseline-sha", required=True, help="exact immutable pre-M1 HomeKV commit")
+    return parser.parse_args()
+
+
+def load_bundle(path: Path, baseline_sha: str) -> dict[str, Any]:
+    data = json.loads(path.read_text())
+    if data.get("authoritative_performance_result") is not False:
+        raise ValueError(f"{path}: M0 bundle must be explicitly non-authoritative")
+    results = data.get("results")
+    if not isinstance(results, list) or not results:
+        raise ValueError(f"{path}: missing non-empty results array")
+    for result in results:
+        environment = result.get("environment", {})
+        if environment.get("homekv_git_sha") != baseline_sha:
+            raise ValueError(
+                f"{path}: result commit {environment.get('homekv_git_sha')!r} != {baseline_sha}"
+            )
+    return data
+
+
+def load_repetitions(root: Path, prefix: str, baseline_sha: str) -> list[tuple[Path, dict[str, Any]]]:
+    files = sorted(root.glob(f"{prefix}-run-*.json"))
+    if len(files) != EXPECTED_REPETITIONS:
+        raise ValueError(
+            f"expected {EXPECTED_REPETITIONS} {prefix} repetitions, found {len(files)}"
+        )
+    return [(path, load_bundle(path, baseline_sha)) for path in files]
+
+
+def cell_key(result: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        result["layer"],
+        result["workload"],
+        result["key_size"],
+        result["value_size"],
+        result["dataset_cardinality"],
+        result["concurrency"],
+    )
+
+
+def aggregate(repetitions: Iterable[tuple[Path, dict[str, Any]]]) -> dict[tuple[Any, ...], dict[str, Any]]:
+    grouped: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+    for _, bundle in repetitions:
+        seen: set[tuple[Any, ...]] = set()
+        for result in bundle["results"]:
+            key = cell_key(result)
+            if key in seen:
+                raise ValueError(f"duplicate result cell within repetition: {key}")
+            seen.add(key)
+            grouped[key].append(result)
+
+    aggregated: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for key, rows in grouped.items():
+        if len(rows) != EXPECTED_REPETITIONS:
+            raise ValueError(f"cell {key} has {len(rows)} repetitions, expected {EXPECTED_REPETITIONS}")
+        throughputs = [float(row["throughput_ops_sec"]) for row in rows]
+        measured = [int(row["measured_operations"]) for row in rows]
+        attempted = [int(row["attempted_operations"]) for row in rows]
+        failures = [int(row.get("failures", 0)) for row in rows]
+        p50 = [int(row["latency_ns"]["p50"]) for row in rows]
+        p95 = [int(row["latency_ns"]["p95"]) for row in rows]
+        p99 = [int(row["latency_ns"]["p99"]) for row in rows]
+        med_throughput = float(median(throughputs))
+        spread = 0.0 if med_throughput == 0 else (max(throughputs) - min(throughputs)) / med_throughput
+        min_measured = min(measured)
+        min_tail = max(1, math.ceil(min_measured * 0.01))
+        aggregated[key] = {
+            "throughput": med_throughput,
+            "throughput_min": min(throughputs),
+            "throughput_max": max(throughputs),
+            "throughput_spread": spread,
+            "p50": int(median(p50)),
+            "p95": int(median(p95)),
+            "p99": int(median(p99)),
+            "min_measured": min_measured,
+            "min_attempted": min(attempted),
+            "max_failures": max(failures),
+            "min_p99_tail_observations": min_tail,
+        }
+    return aggregated
+
+
+def require_cells(agg: dict[tuple[Any, ...], dict[str, Any]]) -> None:
+    missing: list[tuple[Any, ...]] = []
+    for dataset in PRIMARY_DATASETS:
+        for workload in WORKLOADS:
+            key = ("storage", workload, PRIMARY_KEY_SIZE, PRIMARY_VALUE_SIZE, dataset, 1)
+            if key not in agg:
+                missing.append(key)
+    for dataset in PRIMARY_DATASETS:
+        for concurrency in PRIMARY_CONCURRENCY:
+            for workload in WORKLOADS:
+                key = (
+                    "server",
+                    workload,
+                    PRIMARY_KEY_SIZE,
+                    PRIMARY_VALUE_SIZE,
+                    dataset,
+                    concurrency,
+                )
+                if key not in agg:
+                    missing.append(key)
+    for key_size, value_size in PAYLOAD_CASES:
+        for workload in WORKLOADS:
+            key = (
+                "server",
+                workload,
+                key_size,
+                value_size,
+                PAYLOAD_DATASET,
+                PAYLOAD_CONCURRENCY,
+            )
+            if key not in agg:
+                missing.append(key)
+    if missing:
+        formatted = "\n".join(f"- {key}" for key in missing)
+        raise ValueError(f"mandatory M0 cells missing:\n{formatted}")
+
+
+def ns_to_us(value: int) -> float:
+    return value / 1_000.0
+
+
+def fmt_ops(value: float) -> str:
+    return f"{value:,.0f}"
+
+
+def fmt_us(value: int) -> str:
+    return f"{ns_to_us(value):,.1f}"
+
+
+def add_table(lines: list[str], headers: list[str], rows: Iterable[list[str]]) -> None:
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("| " + " | ".join("---" for _ in headers) + " |")
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+
+
+def ratio(numerator: float, denominator: float) -> float:
+    return float("nan") if denominator == 0 else numerator / denominator
+
+
+def build_report(
+    root: Path,
+    baseline_sha: str,
+    storage: dict[tuple[Any, ...], dict[str, Any]],
+    server: dict[tuple[Any, ...], dict[str, Any]],
+) -> str:
+    agg = {**storage, **server}
+    require_cells(agg)
+
+    lines = [
+        "# HomeKV M0 Baseline Analysis",
+        "",
+        f"- Frozen pre-M1 commit: `{baseline_sha}`",
+        f"- Repetitions: {EXPECTED_REPETITIONS} storage + {EXPECTED_REPETITIONS} server",
+        "- Semantics: single-node prototype baseline; **not** distributed/strong-consistency performance",
+        "- Aggregation: median of repeated runs; throughput spread is `(max-min)/median`",
+        f"- p99 support flag: fewer than {LOW_P99_TAIL_OBSERVATIONS} expected observations in the top 1% of the smallest repetition is flagged as low-support",
+        "",
+        "## Primary storage baseline",
+        "",
+    ]
+
+    storage_rows: list[list[str]] = []
+    for dataset in PRIMARY_DATASETS:
+        for workload in WORKLOADS:
+            cell = storage[("storage", workload, 16, 64, dataset, 1)]
+            storage_rows.append(
+                [
+                    workload,
+                    f"{dataset:,}",
+                    fmt_ops(cell["throughput"]),
+                    fmt_us(cell["p50"]),
+                    fmt_us(cell["p95"]),
+                    fmt_us(cell["p99"]),
+                    str(cell["min_measured"]),
+                    str(cell["min_p99_tail_observations"]),
+                    f"{cell['throughput_spread'] * 100:.1f}%",
+                ]
+            )
+    add_table(
+        lines,
+        ["workload", "keys", "median ops/s", "p50 us", "p95 us", "p99 us", "min samples", "~top-1% samples", "run spread"],
+        storage_rows,
+    )
+
+    lines.extend(["## Primary server baseline", ""])
+    server_rows: list[list[str]] = []
+    for dataset in PRIMARY_DATASETS:
+        for concurrency in PRIMARY_CONCURRENCY:
+            for workload in WORKLOADS:
+                cell = server[("server", workload, 16, 64, dataset, concurrency)]
+                server_rows.append(
+                    [
+                        workload,
+                        f"{dataset:,}",
+                        str(concurrency),
+                        fmt_ops(cell["throughput"]),
+                        fmt_us(cell["p50"]),
+                        fmt_us(cell["p95"]),
+                        fmt_us(cell["p99"]),
+                        str(cell["min_measured"]),
+                        str(cell["min_p99_tail_observations"]),
+                        str(cell["max_failures"]),
+                        f"{cell['throughput_spread'] * 100:.1f}%",
+                    ]
+                )
+    add_table(
+        lines,
+        ["workload", "keys", "conc", "median ops/s", "p50 us", "p95 us", "p99 us", "min samples", "~top-1% samples", "max failures", "run spread"],
+        server_rows,
+    )
+
+    lines.extend(["## Dataset-size write-cost observations", ""])
+    write_rows: list[list[str]] = []
+    for workload in ("set", "delete", "read80_write20"):
+        base = storage[("storage", workload, 16, 64, 1_000, 1)]
+        for dataset in PRIMARY_DATASETS:
+            cell = storage[("storage", workload, 16, 64, dataset, 1)]
+            write_rows.append(
+                [
+                    workload,
+                    f"{dataset:,}",
+                    fmt_ops(cell["throughput"]),
+                    fmt_us(cell["p50"]),
+                    fmt_us(cell["p99"]),
+                    f"{ratio(cell['throughput'], base['throughput']):.3f}x",
+                    f"{ratio(cell['p50'], base['p50']):.3f}x",
+                ]
+            )
+    add_table(
+        lines,
+        ["workload", "keys", "median ops/s", "p50 us", "p99 us", "throughput vs 1k", "p50 vs 1k"],
+        write_rows,
+    )
+
+    lines.extend(["## Payload sensitivity at 10k keys / concurrency 8", ""])
+    payload_rows: list[list[str]] = []
+    for workload in WORKLOADS:
+        base = server[("server", workload, 16, 64, PAYLOAD_DATASET, PAYLOAD_CONCURRENCY)]
+        for key_size, value_size in PAYLOAD_CASES:
+            cell = server[("server", workload, key_size, value_size, PAYLOAD_DATASET, PAYLOAD_CONCURRENCY)]
+            payload_rows.append(
+                [
+                    workload,
+                    f"{key_size}B/{value_size}B",
+                    fmt_ops(cell["throughput"]),
+                    fmt_us(cell["p50"]),
+                    fmt_us(cell["p99"]),
+                    f"{ratio(cell['throughput'], base['throughput']):.3f}x",
+                    f"{ratio(cell['p50'], base['p50']):.3f}x",
+                ]
+            )
+    add_table(
+        lines,
+        ["workload", "key/value", "median ops/s", "p50 us", "p99 us", "throughput vs 16B/64B", "p50 vs 16B/64B"],
+        payload_rows,
+    )
+
+    low_support = [
+        (key, cell)
+        for key, cell in sorted(agg.items())
+        if cell["min_p99_tail_observations"] < LOW_P99_TAIL_OBSERVATIONS
+    ]
+    lines.extend(["## p99 sample-sufficiency flags", ""])
+    if low_support:
+        lines.append(
+            f"The following cells have fewer than {LOW_P99_TAIL_OBSERVATIONS} expected observations in the top 1% in at least one repetition. Their p99 is retained but should be treated as low-support rather than a stable tail estimate."
+        )
+        lines.append("")
+        for key, cell in low_support:
+            layer, workload, key_size, value_size, dataset, concurrency = key
+            lines.append(
+                f"- `{layer}/{workload}` {key_size}B/{value_size}B, keys={dataset:,}, conc={concurrency}: min samples={cell['min_measured']}, ~top-1% samples={cell['min_p99_tail_observations']}"
+            )
+    else:
+        lines.append(
+            f"No measured cell fell below the mechanical low-support threshold of {LOW_P99_TAIL_OBSERVATIONS} expected top-1% observations."
+        )
+    lines.append("")
+
+    lines.extend(["## Mechanical contract checks", ""])
+    failed_cells = [(key, cell) for key, cell in agg.items() if cell["max_failures"] != 0]
+    lines.append(f"- Mandatory primary/payload cells present: **yes**")
+    lines.append(f"- Exact baseline SHA present in every result: **yes**")
+    lines.append(f"- Repeated runs retained: **yes ({EXPECTED_REPETITIONS} per performance layer)**")
+    lines.append(f"- Non-authoritative M0 labeling retained: **yes**")
+    lines.append(f"- Cells with measured operation failures: **{len(failed_cells)}**")
+    lines.append("")
+    lines.append("This report contains measured observations only. Causal explanations belong in the Spec 0002 verification handoff as explicitly labeled hypotheses.")
+    lines.append("")
+    lines.append(f"Source directory: `{root}`")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    storage_reps = load_repetitions(args.input, "storage", args.baseline_sha)
+    server_reps = load_repetitions(args.input, "server", args.baseline_sha)
+    storage = aggregate(storage_reps)
+    server = aggregate(server_reps)
+    report = build_report(args.input, args.baseline_sha, storage, server)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report)
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/0002-baseline-benchmark/design.md
+++ b/specs/0002-baseline-benchmark/design.md
@@ -1,6 +1,6 @@
 # Spec 0002 — Baseline Benchmark Design
 
-- Status: Accepted
+- Status: Verified
 - Requirements: `requirements.md`
 - Tracking issue: #8
 

--- a/specs/0002-baseline-benchmark/m0-analysis.md
+++ b/specs/0002-baseline-benchmark/m0-analysis.md
@@ -1,0 +1,168 @@
+# Spec 0002 — M0 Baseline Analysis
+
+This document is the durable BENCH-T7 summary derived from the immutable BENCH-T6 artifact.
+
+## Provenance
+
+- frozen pre-M1 HomeKV commit: `bc613b74e8c718a7d002f1cacbd8d51cddbf3067`
+- capture workflow run: [33080513696](https://github.com/softwheel/homekv/actions/runs/33080513696)
+- retained artifact: `homekv-m0-baseline-bc613b74e8c718a7d002f1cacbd8d51cddbf3067`
+- artifact id: `9650486609`
+- artifact SHA-256: `015faf8d87c8d197457ca9c6fd2f2c8d1ab07dc0bc16a2e62a2517335331680c`
+- capture contents: 3 storage repetitions, 3 server repetitions, storage memory evidence, server memory evidence, and three server logs
+- aggregation below: median across the three retained repetitions; throughput spread is `(max - min) / median`
+- semantics: **single-node prototype baseline only; not distributed/strong-consistency performance**
+
+The artifact archive was independently downloaded during BENCH-T7 and its SHA-256 matched the recorded digest exactly before analysis.
+
+## Result completeness
+
+The retained performance data contains 56 unique measured cells per repetition pair:
+
+- 12 storage cells: 4 workloads × 3 dataset sizes
+- 36 primary server cells: 4 workloads × 3 dataset sizes × concurrency 1/8/32
+- 8 additional server payload-sensitivity cells beyond the overlapping 16B/64B primary cell
+
+Every performance cell is present in each of the three repetitions. Across the retained performance rows there are zero measured-operation failures, zero RPC failures, and zero runtime failures.
+
+All performance repetitions record the same environment:
+
+- Rust: `rustc 1.98.0 (88d9e12ae 2026-08-18)`
+- OS: Linux
+- kernel: `6.17.0-1022-azure`
+- CPU: AMD EPYC 7763 64-Core Processor
+- logical CPUs exposed to the runner: 4
+- RAM: 16,770,744,320 bytes
+
+These are GitHub-hosted-runner results and remain explicitly non-authoritative.
+
+## Primary storage baseline — 16B keys / 64B values
+
+| workload | keys | median ops/s | p50 µs | p95 µs | p99 µs | run spread |
+| --- | --- | --- | --- | --- | --- | --- |
+| GET | 1,000 | 3,749,531 | 0.2 | 0.3 | 0.4 | 3.3% |
+| SET | 1,000 | 16,498 | 58.9 | 79.5 | 88.5 | 3.1% |
+| DELETE | 1,000 | 16,542 | 59.0 | 70.4 | 84.8 | 14.9% |
+| 80/20 | 1,000 | 66,775 | 0.3 | 59.3 | 77.8 | 18.6% |
+| GET | 10,000 | 2,551,118 | 0.3 | 0.5 | 0.5 | 9.1% |
+| SET | 10,000 | 1,428 | 685.5 | 757.7 | 794.5 | 3.0% |
+| DELETE | 10,000 | 1,259 | 790.2 | 851.4 | 938.2 | 1.6% |
+| 80/20 | 10,000 | 6,365 | 0.5 | 801.2 | 837.0 | 4.8% |
+| GET | 50,000 | 1,300,585 | 0.7 | 1.0 | 1.3 | 11.0% |
+| SET | 50,000 | 113 | 7,210.1 | 15,737.0 | 18,329.3 | 100.9% |
+| DELETE | 50,000 | 132 | 6,606.7 | 13,379.9 | 14,409.9 | 87.6% |
+| 80/20 | 50,000 | 398 | 2.5 | 14,553.9 | 15,873.4 | 131.5% |
+
+### Dataset-size write-cost trend
+
+The primary storage sweep strongly separates reads from mutations.
+
+- SET throughput is `1.000x / 0.087x / 0.0069x` at 1k / 10k / 50k keys. Median SET latency grows `1.0x / 11.6x / 122.5x`.
+- DELETE throughput is `1.000x / 0.076x / 0.0080x`. Median DELETE latency grows `1.0x / 13.4x / 111.9x`.
+- The 80/20 workload falls from 66,775 ops/s at 1k keys to 398 ops/s at 50k. Its p50 remains read-dominated, while p95/p99 expose the mutation stalls: p99 rises from 77.8 µs to 15.9 ms.
+- GET changes much more gradually: 3.75M ops/s at 1k keys to 1.30M ops/s at 50k, with p50 moving from roughly 0.2 µs to 0.7 µs.
+
+The 50k mutation cells also show high GitHub-runner variance. This is retained evidence, not hidden by selecting the best run.
+
+## Existing Tonic/Tokio server path
+
+At the 10k primary dataset, GET throughput scales with client concurrency while mutation throughput scales only modestly and mutation latency grows sharply.
+
+| workload | concurrency | median ops/s | p50 µs | p95 µs | p99 µs | run spread |
+| --- | --- | --- | --- | --- | --- | --- |
+| GET | 1 | 5,606 | 161.6 | 229.1 | 576.9 | 5.1% |
+| SET | 1 | 733 | 1,311.3 | 1,464.4 | 2,407.7 | 7.6% |
+| DELETE | 1 | 730 | 1,249.1 | 1,460.3 | 3,313.1 | 18.8% |
+| 80/20 | 1 | 2,339 | 166.2 | 1,337.8 | 1,540.2 | 12.3% |
+| GET | 8 | 15,783 | 469.4 | 842.1 | 1,317.7 | 2.6% |
+| SET | 8 | 976 | 7,457.0 | 12,466.6 | 15,434.3 | 6.1% |
+| DELETE | 8 | 1,052 | 7,041.7 | 10,882.1 | 15,328.3 | 13.5% |
+| 80/20 | 8 | 4,113 | 210.5 | 8,744.6 | 9,906.0 | 9.4% |
+| GET | 32 | 26,880 | 1,124.9 | 1,923.2 | 2,484.4 | 1.6% |
+| SET | 32 | 1,100 | 27,611.4 | 36,006.7 | 45,233.7 | 5.1% |
+| DELETE | 32 | 1,157 | 26,935.6 | 30,532.7 | 48,161.7 | 9.4% |
+| 80/20 | 32 | 4,225 | 215.6 | 38,023.5 | 43,745.5 | 20.4% |
+
+The same pattern becomes more pronounced at 50k keys. GET reaches about 26.1k ops/s at concurrency 32, while SET remains about 173 ops/s and its p50 reaches roughly 175 ms. The 50k 80/20 workload at concurrency 32 records p99 around 268 ms.
+
+This is an observation about the current prototype path, not a claim that CPU saturation or a particular lock is the cause. CPU utilization and lock profiling were not captured in M0.
+
+## Payload sensitivity — 10k keys / concurrency 8
+
+| workload | key/value | median ops/s | p50 µs | p99 µs | throughput vs 16B/64B |
+| --- | --- | --- | --- | --- | --- |
+| GET | 16B/64B | 15,783 | 469.4 | 1,317.7 | 1.000x |
+| GET | 16B/256B | 13,706 | 532.5 | 1,752.3 | 0.868x |
+| GET | 32B/1024B | 13,892 | 533.4 | 1,533.8 | 0.880x |
+| SET | 16B/64B | 976 | 7,457.0 | 15,434.3 | 1.000x |
+| SET | 16B/256B | 155 | 46,817.1 | 83,828.4 | 0.159x |
+| SET | 32B/1024B | 84 | 90,155.2 | 138,070.9 | 0.087x |
+| DELETE | 16B/64B | 1,052 | 7,041.7 | 15,328.3 | 1.000x |
+| DELETE | 16B/256B | 153 | 50,459.2 | 81,865.2 | 0.145x |
+| DELETE | 32B/1024B | 93 | 83,650.3 | 132,950.1 | 0.088x |
+| 80/20 | 16B/64B | 4,113 | 210.5 | 9,906.0 | 1.000x |
+| 80/20 | 16B/256B | 597 | 210.8 | 88,335.3 | 0.145x |
+| 80/20 | 32B/1024B | 397 | 239.4 | 114,330.8 | 0.096x |
+
+GET is comparatively insensitive to the larger stored values in this matrix, while mutations become dramatically more expensive as the populated dataset contains more bytes. DELETE targets a guaranteed-missing key, so its payload sensitivity is especially useful evidence that mutation cost is associated with the existing populated-store representation rather than the returned value size of the DELETE operation itself.
+
+## Memory evidence
+
+The memory measurements are process-RSS deltas, not exact heap-allocation accounting.
+
+| layer | key/value | keys | approx RSS B/key | RSS/logical payload |
+| --- | --- | --- | --- | --- |
+| storage | 16B/64B | 1,000 | 180.2 | 2.25x |
+| storage | 16B/64B | 10,000 | 188.4 | 2.36x |
+| storage | 16B/64B | 50,000 | 188.3 | 2.35x |
+| server | 16B/64B | 1,000 | 405.5 | 5.07x |
+| server | 16B/64B | 10,000 | 370.3 | 4.63x |
+| server | 16B/64B | 50,000 | 377.3 | 4.72x |
+| server | 16B/256B | 10,000 | 724.6 | 2.66x |
+| server | 32B/1024B | 10,000 | 2,143.4 | 2.03x |
+
+For the primary storage profile, the approximate isolated RSS delta stabilizes near 188 bytes/key at 10k and 50k keys. The fresh server-process measurement is roughly 370–405 bytes/key for the same logical payload. These figures include allocator/runtime effects and are only a baseline for relative M1 comparison.
+
+## p99 sample sufficiency and stability
+
+M0 records a p99 for every mandatory cell, but not every p99 has equal statistical support.
+
+- Every storage cell intentionally uses a bounded 200-operation measured window because the current COW path becomes pathological at larger datasets. Roughly two observations therefore occupy the top 1%; storage p99 values are **low-support tail estimates** and must not be over-interpreted.
+- The slowest 32B-key/1KiB-value server SET cell has a minimum of 386 successful samples in a repetition, giving roughly four observations in the top 1%; its p99 is also flagged low-support.
+- Other server cells have at least five approximate top-1% observations in the smallest repetition.
+- The largest run-to-run spreads occur in the 50k storage mutation cells: roughly 100.9% for SET, 87.6% for DELETE, and 131.5% for 80/20.
+
+These limitations do not invalidate the mandatory result cells: each contains a measured throughput, p50, p95, p99, and sample count. They do prevent treating the GitHub-hosted M0 tail values as release-quality performance claims.
+
+## Observations vs. hypotheses
+
+### Measured observations
+
+1. Storage mutation cost increases by roughly two orders of magnitude in median latency between the 1k and 50k primary datasets, while GET degrades far less.
+2. Server GET throughput benefits substantially from additional client concurrency; mutation throughput does not scale comparably and mutation tail latency grows with concurrency.
+3. Larger stored values have modest effect on GET throughput but very large effect on SET/DELETE and mixed-workload mutation tails.
+4. The current prototype has substantial run-to-run variance in the largest COW-heavy storage cells.
+5. The retained result set has zero measured/RPC/runtime failures.
+
+### Hypotheses to test in M1, not claims proved by M0
+
+1. The current `Mvcc<BTreeStore>` whole-store copy-on-write behavior is the dominant source of dataset-size and payload-size mutation scaling.
+2. The serialized writer path compounds server mutation latency under concurrency through queueing.
+3. Historical per-request server logging and Tonic/Tokio overhead contribute to server-path latency, but M0 does not isolate their costs.
+
+The first hypothesis is strongly motivated by the code structure and the shape of the storage/payload results, but causal attribution still belongs to M1 comparison/profiling rather than M0 alone.
+
+## M1 comparison contract
+
+Spec 0003 should repeat the same primary storage/server matrix after the shard-owned storage engine is implemented. The highest-value success signal is not an absolute GitHub-runner number; it is the removal of the dataset-size-dependent mutation cliff while preserving semantics.
+
+At minimum, compare:
+
+- SET/DELETE p50/p95/p99 and throughput at 1k/10k/50k keys
+- 80/20 p95/p99, where write stalls are visible despite read-dominated p50
+- concurrency 1/8/32 server behavior
+- 16B/64B vs 16B/256B vs 32B/1KiB payload sensitivity
+- approximate RSS bytes/key
+- run-to-run spread
+
+No RPC/network optimization should be credited as a storage-engine win unless the comparison isolates that change.

--- a/specs/0002-baseline-benchmark/requirements.md
+++ b/specs/0002-baseline-benchmark/requirements.md
@@ -1,6 +1,6 @@
 # Spec 0002 — Baseline Benchmark Requirements
 
-- Status: Accepted
+- Status: Verified
 - Parent spec: `../0001-homekv-v1/`
 - Tracking issue: #8
 

--- a/specs/0002-baseline-benchmark/tasks.md
+++ b/specs/0002-baseline-benchmark/tasks.md
@@ -1,13 +1,13 @@
 # Spec 0002 — Baseline Benchmark Tasks
 
-- Status: Accepted
+- Status: Verified
 - Requirements: `requirements.md`
 - Design: `design.md`
 - Tracking issue: #8
 
-Implementation may begin because this spec is Accepted.
+Implementation is complete and the verification gate has passed.
 
-## BENCH-T1 — Result/config schema
+## BENCH-T1 — Result/config schema — Complete
 
 Requirements: `REQ-BENCH-003/004/008/010/011`
 
@@ -19,7 +19,7 @@ Requirements: `REQ-BENCH-003/004/008/010/011`
 
 Completion: a clean checkout can parse the checked-in smoke config and emit a schema-valid result.
 
-## BENCH-T2 — Storage-engine baseline harness
+## BENCH-T2 — Storage-engine baseline harness — Complete
 
 Requirements: `REQ-BENCH-001` through `REQ-BENCH-007`, `REQ-BENCH-010`
 
@@ -33,7 +33,7 @@ Requirements: `REQ-BENCH-001` through `REQ-BENCH-007`, `REQ-BENCH-010`
 
 Completion: all primary storage workload cells emit valid results without changing production storage semantics.
 
-## BENCH-T3 — Existing server/RPC baseline
+## BENCH-T3 — Existing server/RPC baseline — Complete
 
 Requirements: `REQ-BENCH-001/002/003/004/009/010`
 
@@ -44,7 +44,7 @@ Requirements: `REQ-BENCH-001/002/003/004/009/010`
 
 Completion: server layer results are clearly separated from storage-only results.
 
-## BENCH-T4 — Environment and memory metadata
+## BENCH-T4 — Environment and memory metadata — Complete
 
 Requirements: `REQ-BENCH-004/005`
 
@@ -57,7 +57,7 @@ Requirements: `REQ-BENCH-004/005`
 
 Unknown data is reported as unknown/null rather than guessed.
 
-## BENCH-T5 — CI smoke mode
+## BENCH-T5 — CI smoke mode — Complete
 
 Requirements: `REQ-BENCH-008/011`
 
@@ -66,7 +66,7 @@ Requirements: `REQ-BENCH-008/011`
 - keep runtime bounded
 - ensure smoke output is explicitly non-authoritative
 
-## BENCH-T6 — Capture immutable prototype baseline
+## BENCH-T6 — Capture immutable prototype baseline — Complete
 
 Requirements: `REQ-BENCH-002/003/004/006/007/009/012`
 
@@ -76,13 +76,30 @@ Requirements: `REQ-BENCH-002/003/004/006/007/009/012`
 - preserve exact commit/configuration metadata
 - do not modify M1 storage code in the baseline commit
 
-## BENCH-T7 — Publish M0 summary
+Evidence:
+
+- frozen pre-M1 SHA: `bc613b74e8c718a7d002f1cacbd8d51cddbf3067`
+- workflow run: `33080513696`
+- artifact id: `9650486609`
+- artifact digest: `sha256:015faf8d87c8d197457ca9c6fd2f2c8d1ab07dc0bc16a2e62a2517335331680c`
+- retained repetitions: 3 storage + 3 server, plus storage/server memory bundles
+
+## BENCH-T7 — Publish M0 summary — Complete
 
 - summarize observed scaling/latency trends
 - separate observations from hypotheses
 - identify likely M1 bottlenecks without implementing fixes
 - link raw artifacts/results
+- mechanically validate mandatory result cells and p99 sample support
+- publish a reproducible retained-artifact analyzer
+
+Evidence:
+
+- durable analysis: `m0-analysis.md`
+- deterministic analyzer: `benchmarks/analyze_m0.py`
+- retained-artifact verifier: `.github/workflows/m0-verification.yml`
+- executed requirement/gate record: `verification.md`
 
 ## Verification handoff
 
-When BENCH-T1..T7 are complete, run `verification.md`. Spec 0002 moves to `Verified` only when the mandatory result cells and metadata pass that gate.
+BENCH-T1..T7 are complete. `verification.md` records PASS for REQ-BENCH-001..012 and the M0 acceptance gate. Spec 0002 is **Verified** and M1/#9 may proceed under Spec 0003.

--- a/specs/0002-baseline-benchmark/verification.md
+++ b/specs/0002-baseline-benchmark/verification.md
@@ -1,57 +1,100 @@
 # Spec 0002 — Baseline Benchmark Verification
 
-- Status: Accepted
+- Status: Verified
 - Requirements: `requirements.md`
+- Analysis: `m0-analysis.md`
 - Tracking issue: #8
+
+## Verification result
+
+**PASS.** Spec 0002 satisfies the M0 acceptance gate against the immutable pre-M1 baseline commit `bc613b74e8c718a7d002f1cacbd8d51cddbf3067`.
+
+The retained BENCH-T6 evidence was captured by workflow run [33080513696](https://github.com/softwheel/homekv/actions/runs/33080513696) as artifact `9650486609`, named `homekv-m0-baseline-bc613b74e8c718a7d002f1cacbd8d51cddbf3067`, with digest:
+
+```text
+sha256:015faf8d87c8d197457ca9c6fd2f2c8d1ab07dc0bc16a2e62a2517335331680c
+```
+
+BENCH-T7 independently downloaded that artifact and confirmed the archive SHA-256 exactly before analyzing the retained JSON bundles. The durable result interpretation is in `m0-analysis.md`; `benchmarks/analyze_m0.py` and the `M0 Verification` workflow make the retained-artifact analysis reproducible.
 
 ## Verification matrix
 
-| Requirement | Proof |
-| --- | --- |
-| REQ-BENCH-001 | result bundle includes GET, SET, DELETE, 80/20 GET/SET |
-| REQ-BENCH-002 | full results include 1k/10k/50k datasets and server concurrency 1/8/32 |
-| REQ-BENCH-003 | every result includes throughput + p50/p95/p99 + sample count |
-| REQ-BENCH-004 | result metadata contains commit/toolchain/OS/kernel/CPU/RAM fields |
-| REQ-BENCH-005 | memory metrics included where practical; limitations documented |
-| REQ-BENCH-006 | archived result identifies an exact pre-M1 prototype commit |
-| REQ-BENCH-007 | storage write results are tabulated across dataset cardinality |
-| REQ-BENCH-008 | clean checkout can run documented smoke/full commands |
-| REQ-BENCH-009 | result/summary explicitly labels single-node prototype semantics |
-| REQ-BENCH-010 | same seed/config produces identical generated keys/workload decisions |
-| REQ-BENCH-011 | normal CI runs bounded smoke mode, not the full authoritative matrix |
-| REQ-BENCH-012 | full result bundle retains repeated runs/variance where practical |
+| Requirement | Result | Proof |
+| --- | --- | --- |
+| REQ-BENCH-001 | PASS | storage and server bundles contain GET, SET, DELETE, and deterministic 80/20 GET/SET cells |
+| REQ-BENCH-002 | PASS | primary results contain 1k/10k/50k datasets; server path contains concurrency 1/8/32 |
+| REQ-BENCH-003 | PASS | every performance cell records throughput, p50/p95/p99, and measured operation count |
+| REQ-BENCH-004 | PASS | retained rows record key/value sizes, workload, cardinality, concurrency, exact HomeKV SHA, Rust version, OS/kernel, CPU model, logical CPU count, and RAM |
+| REQ-BENCH-005 | PASS | storage/server RSS evidence and approximate bytes/key are retained; allocations/op remain explicitly deferred as permitted |
+| REQ-BENCH-006 | PASS | every retained result identifies `bc613b74e8c718a7d002f1cacbd8d51cddbf3067`; PR #18 only corrected benchmark preload batching outside the measured window and contains no M1 storage optimization |
+| REQ-BENCH-007 | PASS | `m0-analysis.md` documents the 1k/10k/50k storage mutation-cost trend and ratios |
+| REQ-BENCH-008 | PASS | configs, benchmark binaries, smoke/full commands, immutable capture workflow, analyzer, and verification workflow are version-controlled |
+| REQ-BENCH-009 | PASS | all bundles set `authoritative_performance_result=false` and label results as single-node prototype/non-distributed |
+| REQ-BENCH-010 | PASS | checked-in seed/config generation is deterministic; generator golden-vector and percentile/config tests were exercised by Rust CI before capture |
+| REQ-BENCH-011 | PASS | normal Rust CI runs bounded smoke benchmarks; the full M0 capture is a separate workflow/run |
+| REQ-BENCH-012 | PASS | three complete storage repetitions and three complete server repetitions are retained; run-to-run spread is reported rather than selecting a best run |
 
-## Harness tests
+## Harness and CI evidence
 
-Before baseline capture, verify:
+The implementation slices were merged only after their required checks passed:
 
-- percentile helper against known ordered samples;
-- deterministic generator golden vectors;
-- invalid config rejection;
-- zero/empty sample handling;
-- result JSON round-trip/parseability;
-- smoke config exits successfully on a clean checkout.
+- PR #11 — deterministic/storage benchmark harness
+- PR #15 — existing Tonic/Tokio server benchmark
+- PR #16 — isolated storage/server memory evidence
+- PR #18 — preload batch-size correction for the 32B-key/1KiB-value sensitivity dataset
+- PR #17 — immutable repeated BENCH-T6 capture
 
-## Stability checks
+The retained capture workflow itself completed successfully and validated exactly eight JSON result bundles: three storage repetitions, three server repetitions, one storage-memory bundle, and one server-memory bundle.
 
-- warm each measured path;
-- retain all repeated runs, not only the best;
-- flag cells with too few samples for useful p99 interpretation;
-- record obvious CPU saturation/queueing conditions;
-- do not compare results across unrecorded configuration changes.
+The BENCH-T7 verification workflow adds a second guard: it checks the retained artifact id/name/digest/run identity, downloads that exact T6 artifact, validates mandatory cells and repetitions with `benchmarks/analyze_m0.py`, and emits a derived Markdown report without rerunning the historical benchmark.
 
 ## M0 acceptance gate
 
-Spec 0002 becomes `Verified` when:
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| 1. harness/configs merged | PASS | BENCH-T1..T5 merged before capture |
+| 2. smoke mode passes CI | PASS | Rust workflow on the implementation/capture PRs |
+| 3. exact pre-M1 baseline captured | PASS | frozen SHA `bc613b74e8c718a7d002f1cacbd8d51cddbf3067` |
+| 4. mandatory primary cells have valid throughput/p50/p95/p99 | PASS | all required storage/server cells present with zero measured/RPC/runtime failures |
+| 5. payload-sensitivity cells captured | PASS | 16B/256B and 32B/1KiB at 10k keys/concurrency 8 retained for all workloads |
+| 6. environment metadata complete where exposed | PASS | Rust/OS/kernel/CPU/logical CPUs/RAM all present and consistent across repetitions |
+| 7. dataset-size write-cost trend documented | PASS | `m0-analysis.md` |
+| 8. results explicitly non-distributed | PASS | bundle flag + per-result notes + analysis labeling |
+| 9. no M1 storage optimization in baseline | PASS | frozen commit is the corrected M0 prototype; M1/#9 remained blocked during capture and analysis |
 
-1. benchmark harness/configs are merged;
-2. smoke mode passes CI;
-3. the prototype baseline is captured against an exact pre-M1 commit;
-4. all mandatory primary workload cells have valid p50/p95/p99 and throughput results;
-5. payload-sensitivity cells are captured or a documented host-resource limitation is accepted by a spec amendment;
-6. environment metadata is complete to the extent exposed by the host;
-7. dataset-size write-cost trend is documented;
-8. results are explicitly labeled single-node prototype/non-distributed;
-9. no M1 storage optimization is present in the baseline commit.
+## Stability and interpretation checks
 
-The verified baseline becomes the comparison point for Spec 0003 (shard-owned memory engine).
+- warm-up is part of every measured path before recorded operations;
+- all three repetitions are retained and summarized by median plus run spread;
+- every storage cell uses the accepted bounded 200-operation mode, so its p99 has only about two top-1% observations and is explicitly flagged as a **low-support tail estimate**;
+- the slow 32B-key/1KiB-value server SET sensitivity cell has a minimum 386 successful samples in a repetition, or about four top-1% observations, and is also flagged low-support;
+- the other server cells have at least five approximate top-1% observations in their smallest repetition;
+- no CPU-utilization or lock-profile data was captured, so concurrency-related queueing is recorded as an observation and causal attribution is left to M1 profiling;
+- the largest 50k COW-heavy storage cells show high run-to-run spread on the GitHub-hosted runner; those numbers are retained but remain non-authoritative.
+
+Low p99 sample support does **not** fail gate 4: the accepted contract requires recorded valid p50/p95/p99 and sample counts, plus explicit flagging when the tail sample is too small for strong interpretation. That condition is satisfied.
+
+## Verified M0 observations
+
+The baseline establishes a clear comparison point for Spec 0003:
+
+- storage SET median throughput falls from about 16.5k ops/s at 1k keys to about 113 ops/s at 50k keys, while p50 grows from about 59 µs to 7.2 ms;
+- DELETE shows nearly the same dataset-size mutation cliff;
+- storage GET degrades much more gradually across the same cardinalities;
+- server GET throughput benefits from concurrency, while mutation throughput saturates early and mutation latency grows sharply;
+- larger stored values have a modest effect on GET but a dramatic effect on mutation throughput/tails;
+- primary isolated storage RSS is about 188 bytes/key at 10k/50k; fresh server-process RSS is about 370–377 bytes/key for the same 16B/64B logical payload.
+
+These are observations. The hypothesis that whole-store COW is the dominant mutation bottleneck is deferred to M1 comparison/profiling for causal confirmation.
+
+## Residual limitations
+
+- GitHub-hosted runner numbers are not release or comparative performance claims.
+- M0 is single-node and does not measure Raft, durability, or distributed strong consistency.
+- storage p99 sample support is intentionally limited by the bounded COW-heavy operation count.
+- RSS delta is approximate process-level evidence, not allocator-precise bytes/op.
+- the large raw Actions artifact has finite retention; the immutable run/id/digest, durable analysis, and reproducible retained-artifact verifier preserve traceability while the artifact exists.
+
+## Handoff
+
+Spec 0002 is **Verified**. M0/#8 may close and M1/#9 may begin under Spec 0003. The M1 comparison must reuse the accepted M0 dimensions and must not credit unrelated RPC/network changes as storage-engine improvements.


### PR DESCRIPTION
## Summary

Completes BENCH-T7 and the Spec 0002 verification handoff without mixing in any M1 storage optimization.

### What this PR adds

- `benchmarks/analyze_m0.py` — deterministic analyzer for the retained BENCH-T6 JSON bundles
- `M0 Verification` workflow — verifies the exact retained artifact identity, downloads run `33080513696` / artifact `9650486609`, and analyzes that evidence rather than recapturing on a new runner
- `specs/0002-baseline-benchmark/m0-analysis.md` — durable repeated-run analysis, payload sensitivity, memory evidence, p99-support caveats, and observations vs hypotheses
- executed `REQ-BENCH-001..012` verification matrix and M0 acceptance gate
- Spec 0002 state transition to **Verified**

## Immutable evidence

- frozen pre-M1 SHA: `bc613b74e8c718a7d002f1cacbd8d51cddbf3067`
- capture run: `33080513696`
- artifact id: `9650486609`
- artifact digest: `sha256:015faf8d87c8d197457ca9c6fd2f2c8d1ab07dc0bc16a2e62a2517335331680c`
- repetitions: 3 storage + 3 server, plus storage/server memory evidence

BENCH-T7 independently downloaded the artifact and confirmed the archive SHA-256 exactly before analysis.

## Key M0 observations

- storage SET: ~16.5k ops/s / 58.9 µs p50 at 1k keys -> ~113 ops/s / 7.2 ms p50 at 50k keys
- storage DELETE shows a similar dataset-size mutation cliff; GET degrades much more gradually
- 10k server GET scales from ~5.6k -> 15.8k -> 26.9k ops/s at concurrency 1/8/32, while SET only moves ~733 -> 976 -> 1,100 ops/s and p50 grows ~1.3 ms -> 7.5 ms -> 27.6 ms
- larger stored payloads modestly affect GET but sharply worsen mutation throughput/tails
- zero measured/RPC/runtime failures across retained performance cells

The likely whole-store-COW bottleneck remains an explicitly labeled M1 hypothesis rather than a causal claim.

## Tail/stability caveat

Storage uses the accepted bounded 200-operation window, so storage p99 values have only ~2 observations in the top 1% and are flagged as low-support tail estimates. One slow 32B/1KiB server SET sensitivity cell is similarly flagged. This satisfies the accepted verification rule: retain the p99/sample count and flag insufficient tail support rather than hiding it.

## SDD traceability

Closes BENCH-T7 for #8 and moves Spec 0002 to **Verified** only if this PR's verification gates pass. M1/#9 remains blocked until merge.
