### PR TITLE
m1: add bounded admission and shard lifecycle

### DIFF
--- a/src/storage/shard_engine.rs
+++ b/src/storage/shard_engine.rs
@@ -1,13 +1,17 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
+use tokio::task::JoinHandle;
 use xxhash_rust::xxh3::xxh3_64;
 
 pub const LOGICAL_SHARD_COUNT: u16 = 1024;
 const SHARD_MASK: u64 = (LOGICAL_SHARD_COUNT as u64) - 1;
+const LIFE_OPEN: u8 = 0;
+const LIFE_CLOSING: u8 = 1;
+const LIFE_CLOSED: u8 = 2;
 
 pub type ShardEngineResult<T> = std::result::Result<T, ShardEngineError>;
 
@@ -29,7 +33,6 @@ impl ShardId {
 }
 
 pub fn shard_for_key(key: &[u8]) -> ShardId {
-    // Masking the low ten bits guarantees the value is always in 0..1024.
     ShardId((xxh3_64(key) & SHARD_MASK) as u16)
 }
 
@@ -58,7 +61,6 @@ impl ShardBatch {
         if mutations.is_empty() {
             return Err(ShardEngineError::EmptyBatch);
         }
-
         for mutation in &mutations {
             let actual = shard_for_key(mutation.key());
             if actual != shard_id {
@@ -68,7 +70,6 @@ impl ShardBatch {
                 });
             }
         }
-
         Ok(Self {
             shard_id,
             mutations,
@@ -98,15 +99,10 @@ pub struct ShardMetrics {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ShardEngineError {
     InvalidShard(u16),
-    WrongShard {
-        expected: ShardId,
-        actual: ShardId,
-    },
-    CrossShardBatch {
-        expected: ShardId,
-        actual: ShardId,
-    },
+    WrongShard { expected: ShardId, actual: ShardId },
+    CrossShardBatch { expected: ShardId, actual: ShardId },
     EmptyBatch,
+    QueueFull,
     Closed,
     OwnerStopped,
 }
@@ -130,6 +126,7 @@ impl fmt::Display for ShardEngineError {
                 expected.as_u16()
             ),
             ShardEngineError::EmptyBatch => write!(f, "atomic shard batch must not be empty"),
+            ShardEngineError::QueueFull => write!(f, "shard admission queue is full"),
             ShardEngineError::Closed => write!(f, "shard engine is closed"),
             ShardEngineError::OwnerStopped => write!(f, "shard owner stopped before replying"),
         }
@@ -138,12 +135,15 @@ impl fmt::Display for ShardEngineError {
 
 impl std::error::Error for ShardEngineError {}
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ShardEngine {
     shard_id: ShardId,
     queue_capacity: usize,
     tx: mpsc::Sender<Request>,
     overload_rejections: Arc<AtomicU64>,
+    lifecycle: Arc<AtomicU8>,
+    admission: Arc<RwLock<()>>,
+    owner_task: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 enum Request {
@@ -167,10 +167,18 @@ enum Request {
     Metrics {
         reply: oneshot::Sender<ShardEngineResult<OwnerMetrics>>,
     },
+    Shutdown {
+        reply: oneshot::Sender<ShardEngineResult<()>>,
+    },
     #[cfg(test)]
     Snapshot {
         keys: Vec<Vec<u8>>,
         reply: oneshot::Sender<ShardEngineResult<Vec<Option<Vec<u8>>>>>,
+    },
+    #[cfg(test)]
+    Pause {
+        entered: oneshot::Sender<()>,
+        release: oneshot::Receiver<()>,
     },
 }
 
@@ -197,12 +205,8 @@ impl OwnerState {
         let key_len = key.len();
         let value_len = value.len();
         match self.data.insert(key, value) {
-            Some(previous) => {
-                self.logical_bytes = self.logical_bytes - previous.len() + value_len;
-            }
-            None => {
-                self.logical_bytes += key_len + value_len;
-            }
+            Some(previous) => self.logical_bytes = self.logical_bytes - previous.len() + value_len,
+            None => self.logical_bytes += key_len + value_len,
         }
         self.applied_mutations += 1;
     }
@@ -222,8 +226,6 @@ impl OwnerState {
     }
 
     fn apply_batch(&mut self, batch: ShardBatch) {
-        // Candidate A's owner loop contains no await/yield inside this call, so no
-        // other GET or mutation can observe a partially applied batch.
         for mutation in batch.mutations {
             self.apply_mutation(mutation);
         }
@@ -241,15 +243,16 @@ impl OwnerState {
 impl ShardEngine {
     pub fn spawn(shard_id: ShardId, queue_capacity: usize) -> Self {
         assert!(queue_capacity > 0, "shard queue capacity must be positive");
-
         let (tx, rx) = mpsc::channel(queue_capacity);
-        tokio::spawn(owner_loop(rx));
-
+        let owner_task = tokio::spawn(owner_loop(rx));
         Self {
             shard_id,
             queue_capacity,
             tx,
             overload_rejections: Arc::new(AtomicU64::new(0)),
+            lifecycle: Arc::new(AtomicU8::new(LIFE_OPEN)),
+            admission: Arc::new(RwLock::new(())),
+            owner_task: Arc::new(Mutex::new(Some(owner_task))),
         }
     }
 
@@ -273,46 +276,130 @@ impl ShardEngine {
         }
     }
 
+    fn ensure_open(&self) -> ShardEngineResult<()> {
+        if self.lifecycle.load(Ordering::Acquire) == LIFE_OPEN {
+            Ok(())
+        } else {
+            Err(ShardEngineError::Closed)
+        }
+    }
+
+    fn map_try_send_error(&self, error: mpsc::error::TrySendError<Request>) -> ShardEngineError {
+        match error {
+            mpsc::error::TrySendError::Full(_) => {
+                self.overload_rejections.fetch_add(1, Ordering::Relaxed);
+                ShardEngineError::QueueFull
+            }
+            mpsc::error::TrySendError::Closed(_) => ShardEngineError::Closed,
+        }
+    }
+
+    async fn join_owner(&self) -> ShardEngineResult<()> {
+        let mut owner_task = self.owner_task.lock().await;
+        if let Some(handle) = owner_task.take() {
+            handle.await.map_err(|_| ShardEngineError::OwnerStopped)?;
+        }
+        Ok(())
+    }
+
     pub async fn get(&self, key: &[u8]) -> ShardEngineResult<Option<Vec<u8>>> {
         self.validate_key(key)?;
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(Request::Get {
-                key: key.to_vec(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| ShardEngineError::Closed)?;
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .send(Request::Get {
+                    key: key.to_vec(),
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| ShardEngineError::Closed)?;
+        }
+        reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
+    }
 
+    pub async fn try_get(&self, key: &[u8]) -> ShardEngineResult<Option<Vec<u8>>> {
+        self.validate_key(key)?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .try_send(Request::Get {
+                    key: key.to_vec(),
+                    reply: reply_tx,
+                })
+                .map_err(|error| self.map_try_send_error(error))?;
+        }
         reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
     }
 
     pub async fn put(&self, key: Vec<u8>, value: Vec<u8>) -> ShardEngineResult<()> {
         self.validate_key(&key)?;
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(Request::Put {
-                key,
-                value,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| ShardEngineError::Closed)?;
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .send(Request::Put {
+                    key,
+                    value,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| ShardEngineError::Closed)?;
+        }
+        reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
+    }
 
+    pub async fn try_put(&self, key: Vec<u8>, value: Vec<u8>) -> ShardEngineResult<()> {
+        self.validate_key(&key)?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .try_send(Request::Put {
+                    key,
+                    value,
+                    reply: reply_tx,
+                })
+                .map_err(|error| self.map_try_send_error(error))?;
+        }
         reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
     }
 
     pub async fn delete(&self, key: Vec<u8>) -> ShardEngineResult<()> {
         self.validate_key(&key)?;
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(Request::Delete {
-                key,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| ShardEngineError::Closed)?;
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .send(Request::Delete {
+                    key,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| ShardEngineError::Closed)?;
+        }
+        reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
+    }
 
+    pub async fn try_delete(&self, key: Vec<u8>) -> ShardEngineResult<()> {
+        self.validate_key(&key)?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .try_send(Request::Delete {
+                    key,
+                    reply: reply_tx,
+                })
+                .map_err(|error| self.map_try_send_error(error))?;
+        }
         reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
     }
 
@@ -323,40 +410,93 @@ impl ShardEngine {
                 actual: batch.shard_id,
             });
         }
-
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(Request::Batch {
-                batch,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| ShardEngineError::Closed)?;
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .send(Request::Batch {
+                    batch,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| ShardEngineError::Closed)?;
+        }
+        reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
+    }
 
+    pub async fn try_apply_batch(&self, batch: ShardBatch) -> ShardEngineResult<()> {
+        if batch.shard_id != self.shard_id {
+            return Err(ShardEngineError::WrongShard {
+                expected: self.shard_id,
+                actual: batch.shard_id,
+            });
+        }
+        let (reply_tx, reply_rx) = oneshot::channel();
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .try_send(Request::Batch {
+                    batch,
+                    reply: reply_tx,
+                })
+                .map_err(|error| self.map_try_send_error(error))?;
+        }
         reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
     }
 
     pub async fn metrics(&self) -> ShardEngineResult<ShardMetrics> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(Request::Metrics { reply: reply_tx })
-            .await
-            .map_err(|_| ShardEngineError::Closed)?;
-
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .send(Request::Metrics { reply: reply_tx })
+                .await
+                .map_err(|_| ShardEngineError::Closed)?;
+        }
         let owner = reply_rx
             .await
             .map_err(|_| ShardEngineError::OwnerStopped)??;
-        let queue_depth = self.queue_capacity.saturating_sub(self.tx.capacity());
-
         Ok(ShardMetrics {
             shard_id: self.shard_id,
             key_count: owner.key_count,
             logical_bytes: owner.logical_bytes,
             queue_capacity: self.queue_capacity,
-            queue_depth,
+            queue_depth: self.queue_capacity.saturating_sub(self.tx.capacity()),
             overload_rejections: self.overload_rejections.load(Ordering::Relaxed),
             applied_mutations: owner.applied_mutations,
         })
+    }
+
+    pub async fn shutdown(&self) -> ShardEngineResult<()> {
+        let admission = self.admission.write().await;
+        match self.lifecycle.load(Ordering::Acquire) {
+            LIFE_CLOSED => return Ok(()),
+            LIFE_CLOSING => {
+                drop(admission);
+                let result = self.join_owner().await;
+                self.lifecycle.store(LIFE_CLOSED, Ordering::Release);
+                return result;
+            }
+            LIFE_OPEN => {}
+            _ => unreachable!("valid lifecycle state"),
+        }
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(Request::Shutdown { reply: reply_tx })
+            .await
+            .map_err(|_| ShardEngineError::Closed)?;
+        self.lifecycle.store(LIFE_CLOSING, Ordering::Release);
+        drop(admission);
+
+        let reply_result = reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?;
+        let join_result = self.join_owner().await;
+        self.lifecycle.store(LIFE_CLOSED, Ordering::Release);
+        reply_result?;
+        join_result
     }
 
     #[cfg(test)]
@@ -365,31 +505,48 @@ impl ShardEngine {
             self.validate_key(key)?;
         }
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(Request::Snapshot {
-                keys: keys.to_vec(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| ShardEngineError::Closed)?;
-
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .send(Request::Snapshot {
+                    keys: keys.to_vec(),
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| ShardEngineError::Closed)?;
+        }
         reply_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?
+    }
+
+    #[cfg(test)]
+    async fn pause_owner(&self) -> ShardEngineResult<oneshot::Sender<()>> {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        {
+            let _admission = self.admission.read().await;
+            self.ensure_open()?;
+            self.tx
+                .send(Request::Pause {
+                    entered: entered_tx,
+                    release: release_rx,
+                })
+                .await
+                .map_err(|_| ShardEngineError::Closed)?;
+        }
+        entered_rx.await.map_err(|_| ShardEngineError::OwnerStopped)?;
+        Ok(release_tx)
     }
 }
 
 async fn owner_loop(mut rx: mpsc::Receiver<Request>) {
     let mut state = OwnerState::default();
-
     while let Some(request) = rx.recv().await {
         match request {
             Request::Get { key, reply } => {
                 let _ = reply.send(Ok(state.get(&key)));
             }
-            Request::Put {
-                key,
-                value,
-                reply,
-            } => {
+            Request::Put { key, value, reply } => {
                 state.put(key, value);
                 let _ = reply.send(Ok(()));
             }
@@ -404,10 +561,20 @@ async fn owner_loop(mut rx: mpsc::Receiver<Request>) {
             Request::Metrics { reply } => {
                 let _ = reply.send(Ok(state.metrics()));
             }
+            Request::Shutdown { reply } => {
+                rx.close();
+                let _ = reply.send(Ok(()));
+                break;
+            }
             #[cfg(test)]
             Request::Snapshot { keys, reply } => {
                 let values = keys.iter().map(|key| state.get(key)).collect();
                 let _ = reply.send(Ok(values));
+            }
+            #[cfg(test)]
+            Request::Pause { entered, release } => {
+                let _ = entered.send(());
+                let _ = release.await;
             }
         }
     }
@@ -441,25 +608,25 @@ mod tests {
         panic!("failed to find key outside shard {}", shard.as_u16());
     }
 
+    async fn wait_until_queue_full(engine: &ShardEngine) {
+        for _ in 0..1000 {
+            if engine.tx.capacity() == 0 {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("queue did not become full");
+    }
+
     #[test]
     fn shard_id_bounds_are_fixed_to_1024() {
         assert_eq!(ShardId::new(0).unwrap().as_u16(), 0);
         assert_eq!(ShardId::new(1023).unwrap().as_u16(), 1023);
-        assert_eq!(
-            ShardId::new(1024),
-            Err(ShardEngineError::InvalidShard(1024))
-        );
-        assert_eq!(
-            ShardId::new(u16::MAX),
-            Err(ShardEngineError::InvalidShard(u16::MAX))
-        );
+        assert_eq!(ShardId::new(1024), Err(ShardEngineError::InvalidShard(1024)));
     }
 
     #[test]
     fn xxh3_mapping_golden_vectors_are_stable() {
-        // Upstream XXH3-64(seed=0) vectors:
-        // empty => 0x2d06800538d394c2, low 10 bits => 194
-        // "abc" => 0x78af5f94892f3950, low 10 bits => 336
         assert_eq!(shard_for_key(b"").as_u16(), 194);
         assert_eq!(shard_for_key(b"abc").as_u16(), 336);
     }
@@ -467,14 +634,9 @@ mod tests {
     #[test]
     fn shard_mapping_is_deterministic_and_bounded() {
         for i in 0_u64..10_000 {
-            let mut key = Vec::with_capacity(24);
-            key.extend_from_slice(b"homekv-key-");
-            key.extend_from_slice(&i.to_le_bytes());
-
-            let first = shard_for_key(&key);
-            let second = shard_for_key(&key);
-            assert_eq!(first, second);
-            assert!(first.as_u16() < LOGICAL_SHARD_COUNT);
+            let key = format!("homekv-key-{i}").into_bytes();
+            assert_eq!(shard_for_key(&key), shard_for_key(&key));
+            assert!(shard_for_key(&key).as_u16() < LOGICAL_SHARD_COUNT);
         }
     }
 
@@ -482,22 +644,14 @@ mod tests {
     async fn owner_engine_put_get_delete_round_trip() {
         let key = b"alpha".to_vec();
         let engine = ShardEngine::spawn(shard_for_key(&key), 16);
-        assert_eq!(engine.queue_capacity(), 16);
-
         assert_eq!(engine.get(&key).await.unwrap(), None);
-
         engine.put(key.clone(), b"one".to_vec()).await.unwrap();
         assert_eq!(engine.get(&key).await.unwrap(), Some(b"one".to_vec()));
-
         engine.put(key.clone(), b"two".to_vec()).await.unwrap();
         assert_eq!(engine.get(&key).await.unwrap(), Some(b"two".to_vec()));
-
         engine.delete(key.clone()).await.unwrap();
         assert_eq!(engine.get(&key).await.unwrap(), None);
-
-        // DELETE is deterministic/idempotent for an absent key.
         engine.delete(key.clone()).await.unwrap();
-        assert_eq!(engine.get(&key).await.unwrap(), None);
     }
 
     #[tokio::test]
@@ -506,36 +660,19 @@ mod tests {
         let shard = shard_for_key(&key);
         let engine = ShardEngine::spawn(shard, 8);
         let other = key_for_different_shard(shard);
-        let actual = shard_for_key(&other);
-
-        assert_eq!(
-            engine.put(other.clone(), b"v".to_vec()).await,
-            Err(ShardEngineError::WrongShard {
-                expected: shard,
-                actual,
-            })
-        );
-        assert_eq!(
-            engine.get(&other).await,
-            Err(ShardEngineError::WrongShard {
-                expected: shard,
-                actual,
-            })
-        );
+        assert!(matches!(
+            engine.put(other, b"v".to_vec()).await,
+            Err(ShardEngineError::WrongShard { .. })
+        ));
     }
 
     #[test]
     fn batch_constructor_rejects_empty_and_cross_shard_commands() {
         let key = b"batch-key".to_vec();
         let shard = shard_for_key(&key);
-        assert_eq!(
-            ShardBatch::new(shard, Vec::new()),
-            Err(ShardEngineError::EmptyBatch)
-        );
-
+        assert_eq!(ShardBatch::new(shard, Vec::new()), Err(ShardEngineError::EmptyBatch));
         let other = key_for_different_shard(shard);
-        let actual = shard_for_key(&other);
-        assert_eq!(
+        assert!(matches!(
             ShardBatch::new(
                 shard,
                 vec![Mutation::Put {
@@ -543,57 +680,8 @@ mod tests {
                     value: b"v".to_vec(),
                 }],
             ),
-            Err(ShardEngineError::CrossShardBatch {
-                expected: shard,
-                actual,
-            })
-        );
-    }
-
-    #[tokio::test]
-    async fn atomic_batch_applies_complete_state() {
-        let seed = b"batch-seed".to_vec();
-        let shard = shard_for_key(&seed);
-        let keys = keys_for_shard(shard, 3);
-        let engine = ShardEngine::spawn(shard, 16);
-
-        let initial = ShardBatch::new(
-            shard,
-            keys.iter()
-                .cloned()
-                .map(|key| Mutation::Put {
-                    key,
-                    value: b"old".to_vec(),
-                })
-                .collect(),
-        )
-        .unwrap();
-        engine.apply_batch(initial).await.unwrap();
-        assert!(engine
-            .snapshot(&keys)
-            .await
-            .unwrap()
-            .iter()
-            .all(|value| value.as_deref() == Some(b"old")));
-
-        let replacement = ShardBatch::new(
-            shard,
-            keys.iter()
-                .cloned()
-                .map(|key| Mutation::Put {
-                    key,
-                    value: b"new".to_vec(),
-                })
-                .collect(),
-        )
-        .unwrap();
-        engine.apply_batch(replacement).await.unwrap();
-        assert!(engine
-            .snapshot(&keys)
-            .await
-            .unwrap()
-            .iter()
-            .all(|value| value.as_deref() == Some(b"new")));
+            Err(ShardEngineError::CrossShardBatch { .. })
+        ));
     }
 
     #[tokio::test]
@@ -602,15 +690,11 @@ mod tests {
         let shard = shard_for_key(&seed);
         let keys = keys_for_shard(shard, 4);
         let engine = ShardEngine::spawn(shard, 64);
-
         let start = ShardBatch::new(
             shard,
             keys.iter()
                 .cloned()
-                .map(|key| Mutation::Put {
-                    key,
-                    value: b"a".to_vec(),
-                })
+                .map(|key| Mutation::Put { key, value: b"a".to_vec() })
                 .collect(),
         )
         .unwrap();
@@ -626,10 +710,7 @@ mod tests {
                         shard,
                         keys.iter()
                             .cloned()
-                            .map(|key| Mutation::Put {
-                                key,
-                                value: value.to_vec(),
-                            })
+                            .map(|key| Mutation::Put { key, value: value.to_vec() })
                             .collect(),
                     )
                     .unwrap();
@@ -637,7 +718,6 @@ mod tests {
                 }
             })
         };
-
         let reader = {
             let engine = engine.clone();
             let keys = keys.clone();
@@ -649,7 +729,6 @@ mod tests {
                 }
             })
         };
-
         writer.await.unwrap();
         reader.await.unwrap();
     }
@@ -660,53 +739,131 @@ mod tests {
         let shard = shard_for_key(&seed);
         let keys = keys_for_shard(shard, 3);
         let engine = ShardEngine::spawn(shard, 16);
-
         let a = keys[0].clone();
         let b = keys[1].clone();
         let absent = keys[2].clone();
-
         engine.put(a.clone(), b"123".to_vec()).await.unwrap();
-        let metrics = engine.metrics().await.unwrap();
-        assert_eq!(metrics.key_count, 1);
-        assert_eq!(metrics.logical_bytes, a.len() + 3);
-        assert_eq!(metrics.applied_mutations, 1);
-
+        assert_eq!(engine.metrics().await.unwrap().logical_bytes, a.len() + 3);
         engine.put(a.clone(), b"12345".to_vec()).await.unwrap();
-        let metrics = engine.metrics().await.unwrap();
-        assert_eq!(metrics.key_count, 1);
-        assert_eq!(metrics.logical_bytes, a.len() + 5);
-        assert_eq!(metrics.applied_mutations, 2);
-
         engine.delete(absent).await.unwrap();
-        let metrics = engine.metrics().await.unwrap();
-        assert_eq!(metrics.key_count, 1);
-        assert_eq!(metrics.logical_bytes, a.len() + 5);
-        assert_eq!(metrics.applied_mutations, 3);
-
         let batch = ShardBatch::new(
             shard,
             vec![
-                Mutation::Put {
-                    key: b.clone(),
-                    value: b"x".to_vec(),
-                },
-                Mutation::Put {
-                    key: b.clone(),
-                    value: b"longer".to_vec(),
-                },
-                Mutation::Delete { key: a.clone() },
+                Mutation::Put { key: b.clone(), value: b"x".to_vec() },
+                Mutation::Put { key: b.clone(), value: b"longer".to_vec() },
+                Mutation::Delete { key: a },
             ],
         )
         .unwrap();
         engine.apply_batch(batch).await.unwrap();
-
         let metrics = engine.metrics().await.unwrap();
         assert_eq!(metrics.key_count, 1);
         assert_eq!(metrics.logical_bytes, b.len() + b"longer".len());
         assert_eq!(metrics.applied_mutations, 6);
-        assert_eq!(metrics.queue_capacity, 16);
-        assert!(metrics.queue_depth <= metrics.queue_capacity);
         assert_eq!(metrics.overload_rejections, 0);
+    }
+
+    #[tokio::test]
+    async fn try_admission_reports_queue_full_and_counts_rejection() {
+        let seed = b"overload-seed".to_vec();
+        let shard = shard_for_key(&seed);
+        let keys = keys_for_shard(shard, 2);
+        let engine = ShardEngine::spawn(shard, 1);
+        let release = engine.pause_owner().await.unwrap();
+
+        let queued = {
+            let engine = engine.clone();
+            let key = keys[0].clone();
+            tokio::spawn(async move { engine.try_put(key, b"accepted".to_vec()).await })
+        };
+        wait_until_queue_full(&engine).await;
+        assert_eq!(
+            engine.try_put(keys[1].clone(), b"rejected".to_vec()).await,
+            Err(ShardEngineError::QueueFull)
+        );
+        release.send(()).unwrap();
+        queued.await.unwrap().unwrap();
+        assert_eq!(engine.metrics().await.unwrap().overload_rejections, 1);
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_admission_does_not_apply_mutation() {
+        let seed = b"cancel-before".to_vec();
+        let shard = shard_for_key(&seed);
+        let keys = keys_for_shard(shard, 2);
+        let engine = ShardEngine::spawn(shard, 1);
+        let release = engine.pause_owner().await.unwrap();
+
+        let accepted = {
+            let engine = engine.clone();
+            let key = keys[0].clone();
+            tokio::spawn(async move { engine.try_put(key, b"first".to_vec()).await })
+        };
+        wait_until_queue_full(&engine).await;
+        let waiting = {
+            let engine = engine.clone();
+            let key = keys[1].clone();
+            tokio::spawn(async move { engine.put(key, b"must-not-apply".to_vec()).await })
+        };
+        tokio::task::yield_now().await;
+        waiting.abort();
+        let _ = waiting.await;
+        release.send(()).unwrap();
+        accepted.await.unwrap().unwrap();
+        assert_eq!(engine.get(&keys[1]).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_admission_still_applies_exactly_once() {
+        let seed = b"cancel-after".to_vec();
+        let shard = shard_for_key(&seed);
+        let key = keys_for_shard(shard, 1).remove(0);
+        let engine = ShardEngine::spawn(shard, 2);
+        let release = engine.pause_owner().await.unwrap();
+
+        let accepted = {
+            let engine = engine.clone();
+            let key = key.clone();
+            tokio::spawn(async move { engine.try_put(key, b"committed".to_vec()).await })
+        };
+        for _ in 0..1000 {
+            if engine.tx.capacity() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        accepted.abort();
+        let _ = accepted.await;
+        release.send(()).unwrap();
+        assert_eq!(engine.get(&key).await.unwrap(), Some(b"committed".to_vec()));
+        assert_eq!(engine.metrics().await.unwrap().applied_mutations, 1);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_accepted_work_and_rejects_new_admission() {
+        let seed = b"shutdown-seed".to_vec();
+        let shard = shard_for_key(&seed);
+        let key = keys_for_shard(shard, 1).remove(0);
+        let engine = ShardEngine::spawn(shard, 1);
+        let release = engine.pause_owner().await.unwrap();
+
+        let accepted = {
+            let engine = engine.clone();
+            let key = key.clone();
+            tokio::spawn(async move { engine.try_put(key, b"drained".to_vec()).await })
+        };
+        wait_until_queue_full(&engine).await;
+        let shutdown = {
+            let engine = engine.clone();
+            tokio::spawn(async move { engine.shutdown().await })
+        };
+        tokio::task::yield_now().await;
+        release.send(()).unwrap();
+        accepted.await.unwrap().unwrap();
+        shutdown.await.unwrap().unwrap();
+        assert_eq!(engine.get(&key).await, Err(ShardEngineError::Closed));
+        assert_eq!(engine.try_get(&key).await, Err(ShardEngineError::Closed));
+        engine.shutdown().await.unwrap();
     }
 
     #[tokio::test]
@@ -717,27 +874,16 @@ mod tests {
         let right_shard = shard_for_key(&right_key);
         let left = ShardEngine::spawn(left_shard, 8);
         let right = ShardEngine::spawn(right_shard, 8);
-
         left.put(left_key.clone(), b"left".to_vec()).await.unwrap();
-        right
-            .put(right_key.clone(), b"right".to_vec())
-            .await
-            .unwrap();
-
+        right.put(right_key.clone(), b"right".to_vec()).await.unwrap();
         assert_eq!(left.get(&left_key).await.unwrap(), Some(b"left".to_vec()));
         assert_eq!(right.get(&right_key).await.unwrap(), Some(b"right".to_vec()));
     }
 
     #[test]
     fn mutation_representation_is_deterministic_data() {
-        let a = Mutation::Put {
-            key: b"k".to_vec(),
-            value: b"v".to_vec(),
-        };
-        let b = Mutation::Put {
-            key: b"k".to_vec(),
-            value: b"v".to_vec(),
-        };
+        let a = Mutation::Put { key: b"k".to_vec(), value: b"v".to_vec() };
+        let b = Mutation::Put { key: b"k".to_vec(), value: b"v".to_vec() };
         assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
## Summary

Implements Spec 0003 M1-T5 only.

- adds explicit `QueueFull` overload semantics
- adds `try_get` / `try_put` / `try_delete` / `try_apply_batch` non-waiting queue admission
- increments the existing overload rejection metric only on actual bounded-queue saturation
- adds a shared admission gate across cloned shard handles so shutdown establishes one deterministic boundary
- explicit `shutdown().await` prevents new admission, drains already accepted work, and joins the owner task before returning
- cancellation before successful admission is verified not to apply
- cancellation after successful admission is verified to still apply the accepted mutation exactly once
- saturation and deterministic drain/shutdown tests use a test-only paused owner

## SDD

Covered by already-Accepted Spec 0003:

- `REQ-M1-QUEUE-001/002/003/004`
- `REQ-M1-LIFE-001/002`
- M1-T5 / verification V4

## Scope boundary

No server migration, benchmark changes, Crossbeam promotion, consensus, WAL, protocol redesign, or M2+ work.

Tracks #9.