### PR TITLE
m1: migrate public API to shard-owned store

### DIFF
--- a/src/bin/homekv.rs
+++ b/src/bin/homekv.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -12,8 +11,7 @@ use homekv::honey_bees::failure_detector::FailureDetectorConfig;
 use homekv::honey_bees::server::spawn_gossip;
 use homekv::honey_bees::transport::UdpTransport;
 use homekv::honey_bees::{GossipConfig, HoneyBee, HoneyBees};
-use homekv::storage::Store;
-use homekv::storage::{BTreeStore, Mvcc};
+use homekv::storage::ShardStore;
 
 // GRPC Service
 use homekv_service::home_kv_service_server::{HomeKvService, HomeKvServiceServer};
@@ -26,23 +24,19 @@ mod homekv_service {
 #[derive(Debug)]
 pub struct StoreStatus {
     // RelaxedCounter is more suitable for counting metrics
-    keys_count: Arc<RelaxedCounter>,
-    values_size_in_bytes: Arc<AtomicUsize>,
     cmds_count: Arc<RelaxedCounter>,
 }
 
 impl StoreStatus {
     fn new() -> Self {
         StoreStatus {
-            keys_count: Arc::new(RelaxedCounter::new(0)),
-            values_size_in_bytes: Arc::new(AtomicUsize::new(0)),
             cmds_count: Arc::new(RelaxedCounter::new(0)),
         }
     }
 }
 
 pub struct HomeKvServer {
-    store: Mvcc<BTreeStore>,
+    store: ShardStore,
     status: StoreStatus,
     honey_bees: Arc<Mutex<HoneyBees>>,
 }
@@ -50,10 +44,14 @@ pub struct HomeKvServer {
 impl HomeKvServer {
     pub fn with_honey_bees(honey_bees: Arc<Mutex<HoneyBees>>) -> Self {
         HomeKvServer {
-            store: Mvcc::new(BTreeStore::new()),
+            store: ShardStore::spawn_default(),
             status: StoreStatus::new(),
             honey_bees,
         }
+    }
+
+    fn storage_error() -> Status {
+        Status::new(Code::Internal, "Internal Storage Error")
     }
 }
 
@@ -63,23 +61,21 @@ impl HomeKvService for HomeKvServer {
         &self,
         request: Request<GetRequest>,
     ) -> std::result::Result<Response<GetResponse>, Status> {
-        // Increase Command Calling Count Status
         self.status.cmds_count.inc();
 
         println!("Got a request: {:?}", request);
-
         let keys = request.into_inner().keys;
-        // Vector for storing result records
-        let mut records: Vec<Record> = Vec::new();
-        // Initialize a Read Transaction, which is a reference of the storage
-        let read_txn = self.store.read().await;
-        for key in keys {
-            if let Ok(value) = read_txn.get(key.as_bytes()) {
-                records.push(Record { key, value });
-            } else {
-                return Err(Status::new(Code::Internal, "Internal Storage Error"));
-            }
-        }
+        let raw_keys: Vec<Vec<u8>> = keys.iter().map(|key| key.as_bytes().to_vec()).collect();
+        let values = self
+            .store
+            .get_many(&raw_keys)
+            .await
+            .map_err(|_| Self::storage_error())?;
+        let records = keys
+            .into_iter()
+            .zip(values.into_iter())
+            .map(|(key, value)| Record { key, value })
+            .collect();
 
         Ok(Response::new(GetResponse { records }))
     }
@@ -88,81 +84,19 @@ impl HomeKvService for HomeKvServer {
         &self,
         request: Request<SetRequest>,
     ) -> std::result::Result<Response<SetResponse>, Status> {
-        // Increase Command Calling Count Status
         self.status.cmds_count.inc();
 
         println!("Got a request: {:?}", request);
         let records = request.into_inner().records;
+        let mutations = records
+            .into_iter()
+            .map(|record| (record.key.into_bytes(), record.value))
+            .collect();
 
-        let mut write_txn = self.store.write().await;
-        let mut_store = write_txn.get_mut();
-
-        // Local value of status metrics
-        let mut keys_count = 0;
-        let mut values_size: i32 = 0;
-
-        for record in records {
-            let record_key = record.key.as_bytes();
-
-            if let Some(value) = record.value {
-                // Pump up the local keys_count metric for a new key,
-                // Decrease the local values_size for an existing key
-                match mut_store.get(record_key) {
-                    Ok(Some(old_value)) => {
-                        values_size -= old_value.len() as i32;
-                        println!(
-                            "Dealing with an existing key: {:?}, old_value_size: {}",
-                            record.key,
-                            old_value.len()
-                        );
-                    }
-                    Ok(None) => {
-                        println!("Dealing with a non-existing key: {:?}", record.key);
-                        keys_count += 1;
-                        values_size += value.len() as i32;
-                    }
-                    Err(_) => return Err(Status::new(Code::Internal, "Internal Storage Error")),
-                }
-
-                // Upsert
-                match mut_store.set(record_key, value) {
-                    Err(_) => return Err(Status::new(Code::Internal, "Internal Storage Error")),
-                    Ok(()) => (),
-                }
-            } else {
-                // Decrease keys_count and values_size for removing existing key
-                match mut_store.get(record_key) {
-                    Ok(Some(old_value)) => {
-                        keys_count -= 1;
-                        values_size -= old_value.len() as i32;
-                    }
-                    Ok(None) => (),
-                    Err(_) => return Err(Status::new(Code::Internal, "Internal Storage Error")),
-                }
-
-                // Delete
-                match mut_store.delete(record_key) {
-                    Err(_) => return Err(Status::new(Code::Internal, "Internal Storage Error")),
-                    Ok(()) => (),
-                }
-            }
-        }
-
-        // Commit
-        write_txn.commit().await;
-        // Commit Success
-        // Update Key Count Status
-        self.status.keys_count.add(keys_count);
-        // Update Value Size Status
-        if values_size < 0 {
-            self.status
-                .values_size_in_bytes
-                .fetch_sub(values_size.abs() as usize, Ordering::Relaxed);
-        } else {
-            self.status
-                .values_size_in_bytes
-                .fetch_add(values_size as usize, Ordering::Relaxed);
-        }
+        self.store
+            .set_many(mutations)
+            .await
+            .map_err(|_| Self::storage_error())?;
 
         Ok(Response::new(SetResponse { succ: true }))
     }
@@ -171,43 +105,20 @@ impl HomeKvService for HomeKvServer {
         &self,
         request: Request<DelRequest>,
     ) -> std::result::Result<Response<DelResponse>, Status> {
-        // Increase Command Calling Count Status
         self.status.cmds_count.inc();
 
         println!("Got a request: {:?}", request);
-        let keys = request.into_inner().keys;
+        let keys = request
+            .into_inner()
+            .keys
+            .into_iter()
+            .map(String::into_bytes)
+            .collect();
 
-        let mut write_txn = self.store.write().await;
-        let mut_store = write_txn.get_mut();
-        let mut keys_count: i32 = 0;
-        let mut values_size: i32 = 0;
-
-        for key in keys {
-            let record_key = key.as_bytes();
-
-            // Decrease keys_count and values_size for removing existing key
-            match mut_store.get(record_key) {
-                Ok(Some(old_value)) => {
-                    keys_count -= 1;
-                    values_size -= old_value.len() as i32;
-                }
-                Ok(None) => (),
-                Err(_) => return Err(Status::new(Code::Internal, "Internal Storage Error")),
-            }
-
-            match mut_store.delete(record_key) {
-                Ok(()) => (),
-                Err(_) => return Err(Status::new(Code::Internal, "Internal Storage Error")),
-            }
-        }
-
-        write_txn.commit().await;
-
-        // Commit Success
-        self.status.keys_count.add(keys_count as usize);
-        self.status
-            .values_size_in_bytes
-            .fetch_add(values_size as usize, Ordering::Relaxed);
+        self.store
+            .delete_many(keys)
+            .await
+            .map_err(|_| Self::storage_error())?;
 
         Ok(Response::new(DelResponse { succ: true }))
     }
@@ -218,11 +129,15 @@ impl HomeKvService for HomeKvServer {
         request: Request<()>,
     ) -> std::result::Result<Response<MetricsResponse>, Status> {
         println!("Got a metrics request");
+        let storage = self
+            .store
+            .metrics()
+            .await
+            .map_err(|_| Self::storage_error())?;
         Ok(Response::new(MetricsResponse {
             metrics: Some(Metrics {
-                keys_count: self.status.keys_count.get() as u32,
-                values_size_in_bytes: self.status.values_size_in_bytes.load(Ordering::Relaxed)
-                    as u64,
+                keys_count: storage.key_count as u32,
+                values_size_in_bytes: storage.logical_bytes as u64,
                 cmds_count: self.status.cmds_count.get() as u64,
             }),
         }))

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,12 +1,15 @@
 pub mod btree_store;
 pub mod mvcc;
 pub mod shard_engine;
+pub mod shard_store;
 
 pub use btree_store::BTreeStore;
 pub use mvcc::Mvcc;
 pub use shard_engine::{
-    shard_for_key, Mutation, ShardBatch, ShardEngine, ShardEngineError, ShardId, ShardMetrics,
+    shard_for_key, Mutation, ShardBatch, ShardEngine, ShardEngineError, ShardEngineResult, ShardId,
+    ShardMetrics, LOGICAL_SHARD_COUNT,
 };
+pub use shard_store::{ShardStore, ShardStoreMetrics, DEFAULT_SHARD_QUEUE_CAPACITY};
 
 use crate::common::Result;
 

--- a/src/storage/shard_store.rs
+++ b/src/storage/shard_store.rs
@@ -1,0 +1,178 @@
+use std::collections::BTreeMap;
+
+use super::{shard_for_key, Mutation, ShardBatch, ShardEngine, ShardEngineError, ShardEngineResult, ShardId, LOGICAL_SHARD_COUNT};
+
+pub const DEFAULT_SHARD_QUEUE_CAPACITY: usize = 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ShardStoreMetrics {
+    pub key_count: usize,
+    pub logical_bytes: usize,
+    pub applied_mutations: u64,
+    pub overload_rejections: u64,
+}
+
+#[derive(Clone)]
+pub struct ShardStore {
+    shards: Vec<ShardEngine>,
+}
+
+impl ShardStore {
+    pub fn spawn(queue_capacity: usize) -> Self {
+        assert!(queue_capacity > 0, "shard queue capacity must be positive");
+        let shards = (0..LOGICAL_SHARD_COUNT)
+            .map(|id| ShardEngine::spawn(ShardId::new(id).expect("bounded logical shard id"), queue_capacity))
+            .collect();
+        Self { shards }
+    }
+
+    pub fn spawn_default() -> Self {
+        Self::spawn(DEFAULT_SHARD_QUEUE_CAPACITY)
+    }
+
+    fn shard(&self, key: &[u8]) -> &ShardEngine {
+        &self.shards[shard_for_key(key).as_u16() as usize]
+    }
+
+    pub async fn get(&self, key: &[u8]) -> ShardEngineResult<Option<Vec<u8>>> {
+        self.shard(key).get(key).await
+    }
+
+    pub async fn get_many(&self, keys: &[Vec<u8>]) -> ShardEngineResult<Vec<Option<Vec<u8>>>> {
+        let mut values = Vec::with_capacity(keys.len());
+        for key in keys {
+            values.push(self.get(key).await?);
+        }
+        Ok(values)
+    }
+
+    pub async fn set_many(&self, records: Vec<(Vec<u8>, Option<Vec<u8>>)>) -> ShardEngineResult<()> {
+        let mut by_shard: BTreeMap<u16, Vec<Mutation>> = BTreeMap::new();
+        for (key, value) in records {
+            let shard_id = shard_for_key(&key).as_u16();
+            let mutation = match value {
+                Some(value) => Mutation::Put { key, value },
+                None => Mutation::Delete { key },
+            };
+            by_shard.entry(shard_id).or_default().push(mutation);
+        }
+        for (shard_id, mutations) in by_shard {
+            let shard_id = ShardId::new(shard_id)?;
+            let batch = ShardBatch::new(shard_id, mutations)?;
+            self.shards[shard_id.as_u16() as usize].apply_batch(batch).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn delete_many(&self, keys: Vec<Vec<u8>>) -> ShardEngineResult<()> {
+        self.set_many(keys.into_iter().map(|key| (key, None)).collect()).await
+    }
+
+    pub async fn metrics(&self) -> ShardEngineResult<ShardStoreMetrics> {
+        let mut aggregate = ShardStoreMetrics {
+            key_count: 0,
+            logical_bytes: 0,
+            applied_mutations: 0,
+            overload_rejections: 0,
+        };
+        for shard in &self.shards {
+            let metrics = shard.metrics().await?;
+            aggregate.key_count += metrics.key_count;
+            aggregate.logical_bytes += metrics.logical_bytes;
+            aggregate.applied_mutations += metrics.applied_mutations;
+            aggregate.overload_rejections += metrics.overload_rejections;
+        }
+        Ok(aggregate)
+    }
+
+    pub async fn shutdown(&self) -> ShardEngineResult<()> {
+        for shard in &self.shards {
+            shard.shutdown().await?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for ShardStore {
+    fn default() -> Self {
+        Self::spawn_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn two_keys_same_shard() -> (Vec<u8>, Vec<u8>) {
+        let first = b"adapter-key-a".to_vec();
+        let target = shard_for_key(&first);
+        for i in 0..100_000u32 {
+            let candidate = format!("adapter-key-{i}").into_bytes();
+            if candidate != first && shard_for_key(&candidate) == target {
+                return (first, candidate);
+            }
+        }
+        panic!("failed to find same-shard test key");
+    }
+
+    #[tokio::test]
+    async fn existing_api_semantics_route_through_shards() {
+        let store = ShardStore::spawn(8);
+        let key_a = b"alpha".to_vec();
+        let key_b = b"beta".to_vec();
+
+        store
+            .set_many(vec![
+                (key_a.clone(), Some(b"one".to_vec())),
+                (key_b.clone(), Some(b"two".to_vec())),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.get_many(&[key_a.clone(), key_b.clone()]).await.unwrap(),
+            vec![Some(b"one".to_vec()), Some(b"two".to_vec())]
+        );
+
+        store.delete_many(vec![key_a.clone()]).await.unwrap();
+        assert_eq!(store.get(&key_a).await.unwrap(), None);
+        assert_eq!(store.get(&key_b).await.unwrap(), Some(b"two".to_vec()));
+        store.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn same_shard_set_request_uses_atomic_batch_accounting() {
+        let store = ShardStore::spawn(8);
+        let (key_a, key_b) = two_keys_same_shard();
+        let shard = shard_for_key(&key_a);
+
+        store
+            .set_many(vec![
+                (key_a.clone(), Some(b"one".to_vec())),
+                (key_b.clone(), Some(b"two".to_vec())),
+            ])
+            .await
+            .unwrap();
+
+        let metrics = store.shards[shard.as_u16() as usize].metrics().await.unwrap();
+        assert_eq!(metrics.key_count, 2);
+        assert_eq!(metrics.applied_mutations, 2);
+        store.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_match_public_server_counters() {
+        let store = ShardStore::spawn(8);
+        store
+            .set_many(vec![
+                (b"a".to_vec(), Some(b"123".to_vec())),
+                (b"bb".to_vec(), Some(b"45".to_vec())),
+            ])
+            .await
+            .unwrap();
+        let metrics = store.metrics().await.unwrap();
+        assert_eq!(metrics.key_count, 2);
+        assert_eq!(metrics.logical_bytes, 1 + 3 + 2 + 2);
+        store.shutdown().await.unwrap();
+    }
+}


### PR DESCRIPTION
Implements Spec 0003 M1-T6 only.

- adds a narrow protocol-neutral `ShardStore` adapter over Candidate A's 1,024 logical shard engines
- routes existing gRPC GET/SET/DELETE through the shard-owned engine without changing protobuf/wire types
- groups SET/DELETE mutations by logical shard so same-shard records use the existing atomic batch primitive while cross-shard requests do not imply cross-shard atomicity
- aggregates shard metrics for the existing public metrics response
- adds adapter tests for GET/SET/DELETE semantics, same-shard batch behavior, and aggregate accounting
- leaves M0 benchmark tooling untouched

No M2 protocol redesign, consensus, WAL, placement, or cross-shard transaction work is included.

Tracking: #9 / Spec 0003 M1-T6.