### PR TITLE
spec(m2): accept compact pipelined data plane

### DIFF
--- a/specs/0004-compact-data-plane/design.md
+++ b/specs/0004-compact-data-plane/design.md
@@ -1,0 +1,145 @@
+# Spec 0004 — Compact Pipelined Data Plane Design
+
+- Status: Accepted
+- Requirements: `requirements.md`
+- Tracking issue: #27
+
+## 1. Architecture
+
+M2 adds a dedicated compact TCP data-plane server beside the existing gRPC service. Both terminate at the same verified M1 `ShardStore` adapter. The protocol layer owns framing, decoding, per-connection bounds, response correlation, and routing/error translation; it does not own shard state or distributed authority.
+
+```text
+client
+  -> TCP connection
+  -> bounded frame decoder
+  -> per-connection in-flight permit
+  -> request decoder + shard validation
+  -> M1 ShardStore adapter
+  -> response encoder
+  -> bounded writer
+```
+
+The gRPC path remains intact for compatibility and apples-to-apples local benchmarking.
+
+## 2. Wire format
+
+All fixed-width integers are big-endian.
+
+### Frame prefix (12 bytes)
+
+- `magic: u16` — fixed HomeKV marker `0x484b` (`HK`)
+- `version: u8` — M2 protocol version `1`
+- `kind: u8` — request=`1`, response=`2`
+- `flags: u16` — zero in v1; non-zero reserved bits are rejected
+- `payload_len: u32`
+- `reserved: u16` — zero in v1
+
+The prefix is parsed into stack/local scalar fields before any payload allocation. `payload_len` is checked against the configured maximum first.
+
+### Request payload
+
+Common header:
+
+- `request_id: u64` (non-zero)
+- `shard_id: u16`
+- `op: u8` — GET=`1`, SET=`2`, DELETE=`3`, BATCH=`4`
+- `op_flags: u8` — zero in v1
+
+Operation bodies are explicit length-delimited byte sequences:
+
+- GET/DELETE: `key_len:u32 | key`
+- SET: `key_len:u32 | value_len:u32 | key | value`
+- BATCH: `mutation_count:u16`, followed by mutation records `{kind:u8, reserved:u8, key_len:u32, value_len:u32, key, value}`; DELETE requires `value_len=0`.
+
+### Response payload
+
+- `request_id: u64`
+- `status: u16`
+- `response_flags: u16` (zero in v1)
+- optional status-specific body
+
+GET success includes `value_len:u32 | value`. `not_found` has no value. Routing statuses may include `route_version:u64` and an optional length-delimited endpoint hint. Error strings are not required on the hot path; diagnostics belong in server logs/metrics.
+
+## 3. Connection execution model
+
+Each accepted socket owns:
+
+1. one incremental frame reader;
+2. a bounded semaphore limiting admitted in-flight requests;
+3. a set/map of currently in-flight request IDs bounded by the semaphore;
+4. a bounded response channel;
+5. one writer task that serializes complete response frames.
+
+The reader acquires an in-flight permit before admitting another decoded request. When all permits are consumed it stops advancing application reads until a request completes. This couples network ingestion to bounded execution without creating an unbounded staging queue.
+
+Requests may execute concurrently across shards. The protocol does not impose connection-wide execution ordering. A request's response carries its ID, so response order may differ from request order. Within one shard, all state changes still serialize through the M1 owner queue.
+
+## 4. Cancellation semantics
+
+Before a command is successfully admitted to `ShardStore`, connection cancellation can discard it. Once admitted, dropping the connection/response path does not revoke the command. This preserves the M1 accepted-work boundary exactly.
+
+Writer failure drops pending response delivery but must not cancel already admitted state-machine work.
+
+## 5. Routing model
+
+M2 validates logical shard identity using the verified `shard_for_key(raw_key)` function. For BATCH every key must map to the supplied shard before the batch is admitted.
+
+M2 introduces protocol representations for `wrong_shard` and `stale_route/not_owner`, but it does not invent distributed authority. Before M3/M4, the active local server may only emit route metadata that it actually has. The framing and adapter are designed so a later authoritative placement/leader resolver can be inserted without changing request encoding.
+
+## 6. Status mapping
+
+Suggested stable v1 status numbers:
+
+- `0` OK
+- `1` NOT_FOUND
+- `2` WRONG_SHARD
+- `3` STALE_ROUTE_OR_NOT_OWNER
+- `4` OVERLOADED
+- `5` CLOSED_OR_UNAVAILABLE
+- `6` MALFORMED_REQUEST
+- `7` UNSUPPORTED_VERSION
+- `8` INTERNAL_ERROR
+- `9` DUPLICATE_INFLIGHT_REQUEST_ID
+
+Status values are protocol compatibility surface once Verified.
+
+Malformed framing that destroys stream synchronization (bad magic, impossible prefix, oversized frame) closes the connection after metrics/logging. A well-framed but semantically invalid request may receive a correlated error response and keep the connection open.
+
+## 7. Bounds
+
+Initial defaults are implementation configuration, not permanent wire guarantees:
+
+- max frame: 8 MiB
+- max key: 64 KiB
+- max value: 4 MiB
+- max batch mutations: 1,024
+- max aggregate batch payload: 8 MiB
+- max in-flight requests/connection: 256
+- bounded response queue: at most the in-flight limit
+
+Tests must use much smaller configurable bounds to deterministically prove saturation behavior.
+
+## 8. Codec implementation
+
+Use explicit encode/decode code over byte slices/buffers rather than introducing a schema runtime on the hot path. `bytes::BytesMut` or equivalent reusable buffers are preferred. Parsing must use checked arithmetic and reject trailing/short data according to each operation schema.
+
+No `unsafe` code is required for M2. No zero-copy optimization is accepted if it makes request lifetime extend ambiguously across cancellation or shard ownership.
+
+## 9. Benchmark design
+
+Add a compact-protocol client/harness that drives localhost TCP and compare against the existing gRPC benchmark path under the same M1 local semantics.
+
+Primary matrix:
+
+- 16B keys / 64B values
+- GET, SET, DELETE, 80/20 GET/SET
+- pipeline depth 1 and 32
+- at least 10,000 measured operations/cell
+- 3 repeated runs for comparative evidence
+- p50/p95/p99, throughput, failures, bytes, host/toolchain metadata
+
+M2 has no mandatory speedup threshold at acceptance time; correctness/bounds are mandatory. Performance results guide M3/M7 and must not be presented as durable replicated performance.
+
+## 10. Future integration boundary
+
+M3 replaces the local execution-authority implementation behind the request adapter with a one-shard OpenRaft-backed path. M4 adds authoritative placement/routing for many groups. Neither should require a new frame format merely to add consensus.

--- a/specs/0004-compact-data-plane/requirements.md
+++ b/specs/0004-compact-data-plane/requirements.md
@@ -1,0 +1,102 @@
+# Spec 0004 — Compact Pipelined Data Plane Requirements
+
+- Status: Accepted
+- Parent: `specs/0001-homekv-v1/requirements.md`
+- Tracking issue: #27
+
+## 1. Purpose
+
+M2 replaces transport/protocol overhead on the foreground data path with a compact, bounded, versioned protocol while preserving the verified M1 shard semantics. M2 does not add replicated consensus or durable-write semantics.
+
+## 2. Scope
+
+M2 covers:
+
+- GET, SET/PUT, DELETE, and deterministic single-shard batches;
+- compact binary framing over a reliable byte stream;
+- request pipelining and response correlation;
+- bounded decode/admission behavior;
+- logical-shard routing metadata and explicit safe routing failures;
+- benchmark comparison with the existing gRPC path under equivalent local M1 semantics.
+
+M2 excludes OpenRaft, WAL/snapshots, distributed placement/reconfiguration, lease reads, cross-shard transactions, TLS/authentication policy, and public release performance claims.
+
+## 3. Protocol requirements
+
+**REQ-M2-PROTO-001** — Every frame MUST be self-delimiting with a fixed-size prefix containing protocol version, frame kind, flags/reserved bits, and payload length.
+
+**REQ-M2-PROTO-002** — v1 of the M2 wire protocol MUST use an explicit magic/version combination and MUST reject unsupported versions deterministically before interpreting operation payloads.
+
+**REQ-M2-PROTO-003** — Integers in the wire format MUST use one documented byte order. M2 chooses network byte order (big-endian) for fixed-width integers.
+
+**REQ-M2-PROTO-004** — Request frames MUST carry a non-zero `request_id` chosen by the client and a `shard_id` in `0..1024`.
+
+**REQ-M2-PROTO-005** — Supported request operations are GET, SET, DELETE, and deterministic single-shard BATCH. Unknown operation codes MUST return a protocol error or close the connection according to the malformed-frame rules; they MUST NOT be interpreted as another operation.
+
+**REQ-M2-PROTO-006** — Keys and values remain arbitrary byte strings. The codec MUST be length-delimited and MUST NOT require UTF-8.
+
+**REQ-M2-PROTO-007** — BATCH MUST contain only SET/DELETE mutations and MUST be rejected before application if any encoded key maps to a shard different from the request `shard_id`.
+
+## 4. Framing and bounds
+
+**REQ-M2-BOUND-001** — The server MUST enforce a configured maximum frame size before allocating payload storage for the full frame.
+
+**REQ-M2-BOUND-002** — The server MUST enforce configured maximum key size, value size, batch mutation count, and aggregate batch payload size.
+
+**REQ-M2-BOUND-003** — Invalid lengths, integer overflow, truncated frames, impossible enum values, and reserved-bit violations MUST fail safely and MUST NOT panic the process.
+
+**REQ-M2-BOUND-004** — A client MUST NOT be able to create an unbounded per-connection queue through pipelining. The maximum number of admitted in-flight requests per connection MUST be explicit and bounded.
+
+## 5. Pipelining and ordering
+
+**REQ-M2-PIPE-001** — A connection MAY carry multiple outstanding requests without waiting for earlier responses.
+
+**REQ-M2-PIPE-002** — Responses MUST echo the request `request_id`, allowing responses to be correlated independently of transport order.
+
+**REQ-M2-PIPE-003** — The server MAY complete independent requests out of response order, but operations admitted to one shard MUST retain the M1 owner-queue ordering/atomicity semantics.
+
+**REQ-M2-PIPE-004** — Duplicate simultaneous in-flight `request_id` values on the same connection MUST be rejected as a protocol/request error. M2 does not add exactly-once execution semantics.
+
+**REQ-M2-PIPE-005** — Closing a connection MUST NOT revoke a mutation that was already successfully admitted to its shard owner. Cancellation before successful admission MUST not apply the mutation, preserving M1 semantics.
+
+## 6. Routing and errors
+
+**REQ-M2-ROUTE-001** — The server MUST recompute the expected logical shard from raw key bytes and reject a request whose supplied `shard_id` is inconsistent.
+
+**REQ-M2-ROUTE-002** — The protocol MUST define explicit status codes for at least: success, not-found, wrong-shard, stale-route/not-owner, overloaded, closed/unavailable, malformed-request, unsupported-version, and internal-error.
+
+**REQ-M2-ROUTE-003** — Routing failures MAY include a newer route/map version and endpoint hint, but such hints are advisory in M2 and MUST NOT claim Raft leadership before M3/M4.
+
+**REQ-M2-ROUTE-004** — PUT, DELETE, and deterministic single-shard BATCH remain retry-safe because their command semantics are idempotent. M2 MUST NOT advertise general exactly-once execution.
+
+## 7. Backpressure and resource ownership
+
+**REQ-M2-BP-001** — Socket read progress MUST be coupled to bounded per-connection admission so a slow shard or saturated server cannot accumulate unbounded decoded requests.
+
+**REQ-M2-BP-002** — Shard `QueueFull`/`Closed` outcomes MUST map to explicit protocol statuses rather than silent drop or indefinite buffering.
+
+**REQ-M2-BP-003** — Response buffering MUST be bounded. A persistently slow client MUST eventually experience bounded backpressure or connection termination without unbounded server memory growth.
+
+**REQ-M2-BP-004** — The implementation SHOULD reuse buffers where practical, but zero-copy is not a correctness requirement and MUST NOT weaken ownership/cancellation safety.
+
+## 8. Compatibility
+
+**REQ-M2-COMPAT-001** — The existing gRPC API remains available during M2 as the compatibility/control comparison path unless a later accepted spec removes it.
+
+**REQ-M2-COMPAT-002** — Wire-format changes after Spec 0004 is Verified require a protocol-version change or an accepted backward-compatible amendment.
+
+**REQ-M2-COMPAT-003** — The M2 server MUST keep protocol decoding isolated from shard execution behind a narrow request/response adapter so M3 consensus can replace local execution authority without redesigning framing.
+
+## 9. Performance and observability
+
+**REQ-M2-PERF-001** — The compact path SHOULD reduce healthy local request overhead relative to the existing gRPC path under equivalent M1 semantics; no fixed speedup is required for acceptance unless amended before verification.
+
+**REQ-M2-PERF-002** — Benchmark evidence MUST include GET/SET/DELETE and a mixed workload, at least 1 and 32 pipeline depth, p50/p95/p99, throughput, failures, payload sizes, and host/toolchain metadata.
+
+**REQ-M2-PERF-003** — Benchmark comparisons MUST use equivalent local consistency/durability semantics and MUST retain the existing gRPC path as the comparison point.
+
+**REQ-M2-OPS-001** — The server MUST expose counters/gauges sufficient to observe accepted/rejected frames, active connections, in-flight requests, protocol errors, overload responses, and bytes read/written.
+
+## 10. Acceptance
+
+Spec 0004 may become Verified only when the implementation and tests establish all mandatory protocol, bound, pipelining, routing, backpressure, compatibility, and observability requirements and retain reproducible benchmark evidence. Passing M2 MUST NOT be interpreted as proving distributed linearizability or durable replicated writes; those belong to M3+.

--- a/specs/0004-compact-data-plane/tasks.md
+++ b/specs/0004-compact-data-plane/tasks.md
@@ -1,0 +1,101 @@
+# Spec 0004 — Compact Pipelined Data Plane Tasks
+
+- Status: Accepted
+- Requirements: `requirements.md`
+- Design: `design.md`
+- Tracking issue: #27
+
+Implementation may begin only after this spec is merged to `main` in Accepted state.
+
+## M2-T1 — Wire types and codec
+
+Requirements: `REQ-M2-PROTO-*`, `REQ-M2-BOUND-001/002/003`
+
+- define constants, frame prefix, operation/status enums, request/response models
+- implement checked encode/decode over byte slices/buffers
+- validate magic/version/reserved fields, lengths, key/value/batch bounds
+- add golden wire vectors and malformed/truncation/overflow tests
+
+Completion: deterministic round-trip/golden tests pass and fuzz/property-style malformed inputs do not panic or allocate beyond configured bounds.
+
+## M2-T2 — Bounded connection runtime
+
+Requirements: `REQ-M2-BOUND-004`, `REQ-M2-PIPE-*`, `REQ-M2-BP-*`
+
+- TCP listener and incremental frame reader
+- per-connection in-flight semaphore and duplicate request-ID tracking
+- bounded response channel and single writer task
+- cancellation-before-admission / accepted-work-after-disconnect tests
+- slow-client and saturation tests
+
+Completion: tests prove bounded in-flight/request/response storage and M1 cancellation boundary preservation.
+
+Prerequisite: M2-T1.
+
+## M2-T3 — Shard execution adapter and routing errors
+
+Requirements: `REQ-M2-ROUTE-*`, `REQ-M2-COMPAT-003`
+
+- translate decoded requests to the existing `ShardStore` API
+- recompute/validate shard mapping before admission
+- prevalidate BATCH shard membership
+- map `QueueFull`, `Closed`, wrong-shard and application results to stable protocol statuses
+- keep routing-hint provider abstract/non-authoritative in M2
+
+Completion: integration tests exercise GET/SET/DELETE/BATCH and all mandatory status mappings without introducing consensus/placement authority.
+
+Prerequisite: M2-T1/T2.
+
+## M2-T4 — Compatibility and server integration
+
+Requirements: `REQ-M2-COMPAT-001/002`, parent `REQ-SDD-003`
+
+- run compact server beside current gRPC service
+- configuration for bind address and resource bounds
+- retain gRPC behavior/tests unchanged
+- graceful lifecycle integration without changing M1 shard shutdown semantics
+
+Completion: both protocols operate against the same local shard engine and existing gRPC tests remain green.
+
+Prerequisite: M2-T2/T3.
+
+## M2-T5 — Observability
+
+Requirements: `REQ-M2-OPS-001`
+
+- counters for frames/requests accepted and rejected
+- protocol/malformed/unsupported-version errors
+- overload/closed responses
+- active connections and current/peak in-flight requests
+- bytes read/written
+
+Completion: deterministic metric tests cover success, protocol rejection, overload, disconnect and lifecycle paths.
+
+Prerequisite: M2-T2/T3.
+
+## M2-T6 — Repeated comparative benchmark
+
+Requirements: `REQ-M2-PERF-*`
+
+- compact client benchmark harness
+- equivalent gRPC comparison path
+- 16B/64B GET/SET/DELETE/80-20
+- pipeline depth 1 and 32
+- >=10k measured operations/cell
+- 3 repetitions with exact commit and host metadata
+- retain all artifacts and run spread
+
+Completion: reproducible comparative evidence exists; conclusions explicitly state local M1 semantics and do not claim replicated durability/linearizability.
+
+Prerequisite: M2-T4/T5.
+
+## M2-T7 — Verification handoff
+
+- execute `verification.md` matrix
+- record exact commits, CI/workflow runs and benchmark artifacts
+- document compatibility surface (magic/version/op/status values)
+- separate correctness evidence from performance observations
+- move Spec 0004 to Verified only when every mandatory gate passes
+- close #27 and unblock M3 only after verification merge
+
+Prerequisite: M2-T1..T6.

--- a/specs/0004-compact-data-plane/verification.md
+++ b/specs/0004-compact-data-plane/verification.md
@@ -1,0 +1,127 @@
+# Spec 0004 — Compact Pipelined Data Plane Verification
+
+- Status: Accepted
+- Requirements: `requirements.md`
+- Design: `design.md`
+- Tracking issue: #27
+
+## Requirement matrix
+
+| Requirement | Verification |
+| --- | --- |
+| REQ-M2-PROTO-001..007 | golden vectors, round-trip codec tests, operation/body validation |
+| REQ-M2-BOUND-001..004 | oversized/truncated/overflow/boundary tests; bounded in-flight stress |
+| REQ-M2-PIPE-001..005 | pipelining/correlation/order/duplicate-ID/cancellation tests |
+| REQ-M2-ROUTE-001..004 | shard recomputation, cross-shard batch rejection, status mapping, retry-semantics review |
+| REQ-M2-BP-001..004 | saturated shard, slow reader/writer, queue bound and disconnect tests |
+| REQ-M2-COMPAT-001..003 | gRPC regression suite plus adapter/source review |
+| REQ-M2-PERF-001..003 | repeated compact-vs-gRPC benchmark under equivalent M1 semantics |
+| REQ-M2-OPS-001 | metric state-transition tests |
+
+## V1 — Wire compatibility
+
+Verify exact checked-in bytes for representative GET, SET, DELETE, BATCH, success, not-found, overload, wrong-shard and unsupported-version frames. Golden vectors freeze:
+
+- magic `0x484b`;
+- version `1`;
+- request/response kind values;
+- operation codes;
+- status codes;
+- big-endian integer encoding.
+
+Changing these values after verification requires a version change or accepted compatible amendment.
+
+## V2 — Decoder safety and bounds
+
+Exercise zero/maximum/maximum+1 lengths and malformed prefixes/bodies. Include:
+
+- oversized `payload_len` rejected before full payload allocation;
+- key/value/batch count/aggregate limits;
+- truncated prefix/body;
+- integer arithmetic overflow attempts;
+- invalid op/mutation/status/reserved bits;
+- arbitrary non-UTF8 key/value bytes.
+
+No input may panic the process. Stream-desynchronizing malformed frames must close the connection deterministically.
+
+## V3 — Pipelining and correlation
+
+At configurable in-flight limit N:
+
+- send N distinct requests without awaiting responses;
+- prove the server never admits >N connection requests simultaneously;
+- permit cross-shard completion/response reordering and correlate by `request_id`;
+- prove same-shard mutation history remains explainable by M1 owner order;
+- reject duplicate active request IDs;
+- allow request-ID reuse only after the earlier request has completed and left the in-flight set.
+
+## V4 — Cancellation and backpressure
+
+With tiny deterministic bounds:
+
+- disconnect before shard admission and prove mutation does not apply;
+- disconnect after successful shard admission and prove accepted mutation applies exactly once;
+- saturate a shard and prove explicit OVERLOADED instead of unbounded staging;
+- stop reading responses and prove response memory remains bounded / connection eventually backpressures or closes;
+- prove socket application reads stop advancing when per-connection permits are exhausted.
+
+## V5 — Routing and shard safety
+
+Verify:
+
+- correct raw key + shard is admitted;
+- incorrect supplied shard is rejected before mutation;
+- a BATCH containing any foreign-shard key is rejected atomically before admission;
+- routing hints are absent/advisory unless supplied by an actual provider;
+- M2 does not claim Raft leadership, quorum state or distributed durability.
+
+## V6 — Existing API compatibility
+
+Run the existing gRPC GET/SET/DELETE and M0/M1 smoke gates unchanged. Both gRPC and compact paths must reach the same M1 local store semantics. M2 must not remove or silently alter the external gRPC contract.
+
+## V7 — Observability
+
+For controlled connection/request sequences, assert exact or monotonic expected changes to:
+
+- active connections;
+- accepted/rejected frames;
+- protocol errors;
+- unsupported versions;
+- overload responses;
+- current/peak in-flight requests;
+- bytes read/written.
+
+## V8 — Repeated benchmark
+
+Capture at least three complete runs from one exact commit for compact and gRPC local paths.
+
+Primary cells:
+
+- 16B key / 64B value;
+- GET / SET / DELETE / 80% GET + 20% SET;
+- pipeline depth 1 and 32;
+- >=10,000 measured operations/cell;
+- p50/p95/p99, throughput and failures;
+- host/toolchain metadata.
+
+Report median and run spread. Do not select only the fastest repetition. Any claimed speedup must compare equivalent M1 local semantics and must be labeled as a local data-plane engineering result, not durable replicated performance.
+
+## M2 acceptance checklist
+
+Spec 0004 becomes Verified only when all mandatory items are checked:
+
+- [ ] wire golden compatibility verified
+- [ ] malformed/oversized/truncated decoding is safe and bounded
+- [ ] key/value/batch resource limits verified
+- [ ] per-connection in-flight and response buffering are bounded
+- [ ] request pipelining/correlation and duplicate-ID semantics verified
+- [ ] M1 same-shard ordering and batch atomicity preserved
+- [ ] cancellation before/after admission semantics preserved
+- [ ] shard-ID recomputation and cross-shard batch rejection verified
+- [ ] explicit overload/closed/routing/protocol statuses verified
+- [ ] existing gRPC compatibility path remains green
+- [ ] protocol metrics verified
+- [ ] 3-run compact-vs-gRPC benchmark evidence retained
+- [ ] no OpenRaft/WAL/Multi-Raft/lease-read code mixed into M2
+
+Only after this verification PR merges may #27 close and M3 become unblocked.


### PR DESCRIPTION
Defines and accepts Spec 0004 for HomeKV v1 M2 only.

- freezes a compact versioned binary frame and operation/status compatibility surface
- defines bounded per-connection pipelining, duplicate request-ID handling, response correlation and cancellation semantics
- preserves M1 shard mapping, owner ordering, atomic single-shard batches and accepted-work boundaries
- defines explicit wrong-shard/stale-route/overload/closed/protocol failures without inventing Raft authority
- keeps gRPC as the compatibility/comparison path
- defines observability and a repeated compact-vs-gRPC local benchmark matrix
- explicitly excludes OpenRaft, WAL/snapshots, Multi-Raft, lease reads and distributed durability claims

Tracks #27 and parent #7. No semantic implementation is included in this PR.