### PR TITLE
m2: add shard execution adapter and routing status mapping

### DIFF
--- a/src/data_plane_adapter.rs
+++ b/src/data_plane_adapter.rs
@@ -1,0 +1,291 @@
+use crate::data_plane::{Mutation as WireMutation, Request, RequestBody, Status};
+use crate::data_plane_runtime::{HandlerResponse, RequestHandler};
+use crate::storage::{Mutation, ShardEngineError, ShardStore};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteDisposition {
+    Local,
+    AdvisoryNotOwner,
+}
+
+pub trait RouteHintProvider: Send + Sync + 'static {
+    fn disposition(&self, shard_id: u16) -> RouteDisposition;
+}
+
+#[derive(Debug, Default)]
+pub struct LocalRouteHints;
+
+impl RouteHintProvider for LocalRouteHints {
+    fn disposition(&self, _shard_id: u16) -> RouteDisposition {
+        RouteDisposition::Local
+    }
+}
+
+#[derive(Clone)]
+pub struct ShardRequestHandler<R = LocalRouteHints> {
+    store: ShardStore,
+    route_hints: Arc<R>,
+}
+
+impl ShardRequestHandler<LocalRouteHints> {
+    pub fn local(store: ShardStore) -> Self {
+        Self::new(store, Arc::new(LocalRouteHints))
+    }
+}
+
+impl<R: RouteHintProvider> ShardRequestHandler<R> {
+    pub fn new(store: ShardStore, route_hints: Arc<R>) -> Self {
+        Self { store, route_hints }
+    }
+
+    async fn execute(&self, request: Request) -> HandlerResponse {
+        if self.route_hints.disposition(request.shard_id) == RouteDisposition::AdvisoryNotOwner {
+            return HandlerResponse::new(Status::StaleRouteOrNotOwner, Vec::new());
+        }
+
+        let result = match request.body {
+            RequestBody::Get { key } => match self.store.try_get_on_shard(request.shard_id, &key).await {
+                Ok(Some(value)) => return HandlerResponse::ok(value),
+                Ok(None) => return HandlerResponse::new(Status::NotFound, Vec::new()),
+                Err(error) => Err(error),
+            },
+            RequestBody::Set { key, value } => {
+                self.store.try_put_on_shard(request.shard_id, key, value).await
+            }
+            RequestBody::Delete { key } => {
+                self.store.try_delete_on_shard(request.shard_id, key).await
+            }
+            RequestBody::Batch { mutations } => {
+                let mutations = mutations
+                    .into_iter()
+                    .map(|mutation| match mutation {
+                        WireMutation::Set { key, value } => Mutation::Put { key, value },
+                        WireMutation::Delete { key } => Mutation::Delete { key },
+                    })
+                    .collect();
+                self.store
+                    .try_apply_batch_on_shard(request.shard_id, mutations)
+                    .await
+            }
+        };
+
+        match result {
+            Ok(()) => HandlerResponse::ok(Vec::new()),
+            Err(error) => HandlerResponse::new(status_for_engine_error(&error), Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl<R: RouteHintProvider> RequestHandler for ShardRequestHandler<R> {
+    async fn handle(&self, request: Request) -> HandlerResponse {
+        self.execute(request).await
+    }
+}
+
+pub fn status_for_engine_error(error: &ShardEngineError) -> Status {
+    match error {
+        ShardEngineError::InvalidShard(_)
+        | ShardEngineError::WrongShard { .. }
+        | ShardEngineError::CrossShardBatch { .. } => Status::WrongShard,
+        ShardEngineError::QueueFull => Status::Overloaded,
+        ShardEngineError::Closed => Status::ClosedOrUnavailable,
+        ShardEngineError::EmptyBatch => Status::MalformedRequest,
+        ShardEngineError::OwnerStopped => Status::InternalError,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_plane::{Mutation as WireMutation, RequestBody};
+    use crate::storage::{shard_for_key, ShardId, LOGICAL_SHARD_COUNT};
+
+    fn request(id: u64, shard_id: u16, body: RequestBody) -> Request {
+        Request {
+            request_id: id,
+            shard_id,
+            body,
+        }
+    }
+
+    fn same_shard_keys() -> (Vec<u8>, Vec<u8>) {
+        let first = b"compact-batch-a".to_vec();
+        let target = shard_for_key(&first);
+        for i in 0..100_000u32 {
+            let candidate = format!("compact-batch-{i}").into_bytes();
+            if candidate != first && shard_for_key(&candidate) == target {
+                return (first, candidate);
+            }
+        }
+        panic!("failed to find same-shard key");
+    }
+
+    #[tokio::test]
+    async fn get_set_delete_follow_m1_semantics() {
+        let store = ShardStore::spawn(8);
+        let handler = ShardRequestHandler::local(store.clone());
+        let key = b"compact-key".to_vec();
+        let shard = shard_for_key(&key).as_u16();
+
+        let missing = handler
+            .handle(request(1, shard, RequestBody::Get { key: key.clone() }))
+            .await;
+        assert_eq!(missing.status, Status::NotFound);
+
+        let set = handler
+            .handle(request(
+                2,
+                shard,
+                RequestBody::Set {
+                    key: key.clone(),
+                    value: b"value".to_vec(),
+                },
+            ))
+            .await;
+        assert_eq!(set.status, Status::Ok);
+
+        let get = handler
+            .handle(request(3, shard, RequestBody::Get { key: key.clone() }))
+            .await;
+        assert_eq!(get.status, Status::Ok);
+        assert_eq!(get.body, b"value");
+
+        let delete = handler
+            .handle(request(4, shard, RequestBody::Delete { key: key.clone() }))
+            .await;
+        assert_eq!(delete.status, Status::Ok);
+        assert_eq!(store.get(&key).await.unwrap(), None);
+        store.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wrong_claimed_shard_is_rejected_before_mutation() {
+        let store = ShardStore::spawn(8);
+        let handler = ShardRequestHandler::local(store.clone());
+        let key = b"wrong-route".to_vec();
+        let actual = shard_for_key(&key).as_u16();
+        let wrong = (actual + 1) % LOGICAL_SHARD_COUNT;
+
+        let response = handler
+            .handle(request(
+                1,
+                wrong,
+                RequestBody::Set {
+                    key: key.clone(),
+                    value: b"nope".to_vec(),
+                },
+            ))
+            .await;
+        assert_eq!(response.status, Status::WrongShard);
+        assert_eq!(store.get(&key).await.unwrap(), None);
+        store.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cross_shard_batch_is_rejected_before_application() {
+        let store = ShardStore::spawn(8);
+        let handler = ShardRequestHandler::local(store.clone());
+        let key_a = b"batch-a".to_vec();
+        let shard = shard_for_key(&key_a).as_u16();
+        let key_b = (0..100_000u32)
+            .map(|i| format!("other-{i}").into_bytes())
+            .find(|key| shard_for_key(key).as_u16() != shard)
+            .unwrap();
+
+        let response = handler
+            .handle(request(
+                1,
+                shard,
+                RequestBody::Batch {
+                    mutations: vec![
+                        WireMutation::Set {
+                            key: key_a.clone(),
+                            value: b"a".to_vec(),
+                        },
+                        WireMutation::Set {
+                            key: key_b.clone(),
+                            value: b"b".to_vec(),
+                        },
+                    ],
+                },
+            ))
+            .await;
+        assert_eq!(response.status, Status::WrongShard);
+        assert_eq!(store.get(&key_a).await.unwrap(), None);
+        assert_eq!(store.get(&key_b).await.unwrap(), None);
+        store.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn same_shard_batch_applies_atomically_via_m1_primitive() {
+        let store = ShardStore::spawn(8);
+        let handler = ShardRequestHandler::local(store.clone());
+        let (key_a, key_b) = same_shard_keys();
+        let shard = shard_for_key(&key_a).as_u16();
+
+        let response = handler
+            .handle(request(
+                1,
+                shard,
+                RequestBody::Batch {
+                    mutations: vec![
+                        WireMutation::Set {
+                            key: key_a.clone(),
+                            value: b"a".to_vec(),
+                        },
+                        WireMutation::Set {
+                            key: key_b.clone(),
+                            value: b"b".to_vec(),
+                        },
+                    ],
+                },
+            ))
+            .await;
+        assert_eq!(response.status, Status::Ok);
+        assert_eq!(store.get(&key_a).await.unwrap(), Some(b"a".to_vec()));
+        assert_eq!(store.get(&key_b).await.unwrap(), Some(b"b".to_vec()));
+        store.shutdown().await.unwrap();
+    }
+
+    #[derive(Default)]
+    struct NotOwner;
+
+    impl RouteHintProvider for NotOwner {
+        fn disposition(&self, _shard_id: u16) -> RouteDisposition {
+            RouteDisposition::AdvisoryNotOwner
+        }
+    }
+
+    #[tokio::test]
+    async fn advisory_not_owner_maps_without_claiming_consensus_authority() {
+        let store = ShardStore::spawn(8);
+        let handler = ShardRequestHandler::new(store.clone(), Arc::new(NotOwner));
+        let key = b"hint-only".to_vec();
+        let shard = shard_for_key(&key).as_u16();
+        let response = handler
+            .handle(request(1, shard, RequestBody::Get { key }))
+            .await;
+        assert_eq!(response.status, Status::StaleRouteOrNotOwner);
+        store.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn engine_errors_have_stable_status_translation() {
+        let shard0 = ShardId::new(0).unwrap();
+        let shard1 = ShardId::new(1).unwrap();
+        assert_eq!(status_for_engine_error(&ShardEngineError::QueueFull), Status::Overloaded);
+        assert_eq!(status_for_engine_error(&ShardEngineError::Closed), Status::ClosedOrUnavailable);
+        assert_eq!(status_for_engine_error(&ShardEngineError::OwnerStopped), Status::InternalError);
+        assert_eq!(
+            status_for_engine_error(&ShardEngineError::WrongShard {
+                expected: shard0,
+                actual: shard1,
+            }),
+            Status::WrongShard
+        );
+        assert_eq!(status_for_engine_error(&ShardEngineError::EmptyBatch), Status::MalformedRequest);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod common;
 pub mod consistent_hash;
 pub mod data_plane;
+pub mod data_plane_adapter;
 pub mod data_plane_runtime;
 pub mod honey_bees;
 pub mod storage;

--- a/src/storage/shard_store.rs
+++ b/src/storage/shard_store.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use super::{shard_for_key, Mutation, ShardBatch, ShardEngine, ShardEngineError, ShardEngineResult, ShardId, LOGICAL_SHARD_COUNT};
+use super::{
+    shard_for_key, Mutation, ShardBatch, ShardEngine, ShardEngineError, ShardEngineResult, ShardId,
+    LOGICAL_SHARD_COUNT,
+};
 
 pub const DEFAULT_SHARD_QUEUE_CAPACITY: usize = 1024;
 
@@ -21,7 +24,12 @@ impl ShardStore {
     pub fn spawn(queue_capacity: usize) -> Self {
         assert!(queue_capacity > 0, "shard queue capacity must be positive");
         let shards = (0..LOGICAL_SHARD_COUNT)
-            .map(|id| ShardEngine::spawn(ShardId::new(id).expect("bounded logical shard id"), queue_capacity))
+            .map(|id| {
+                ShardEngine::spawn(
+                    ShardId::new(id).expect("bounded logical shard id"),
+                    queue_capacity,
+                )
+            })
             .collect();
         Self { shards }
     }
@@ -34,8 +42,50 @@ impl ShardStore {
         &self.shards[shard_for_key(key).as_u16() as usize]
     }
 
+    fn declared_shard(&self, shard_id: u16) -> ShardEngineResult<&ShardEngine> {
+        let shard_id = ShardId::new(shard_id)?;
+        Ok(&self.shards[shard_id.as_u16() as usize])
+    }
+
     pub async fn get(&self, key: &[u8]) -> ShardEngineResult<Option<Vec<u8>>> {
         self.shard(key).get(key).await
+    }
+
+    pub async fn try_get_on_shard(
+        &self,
+        shard_id: u16,
+        key: &[u8],
+    ) -> ShardEngineResult<Option<Vec<u8>>> {
+        self.declared_shard(shard_id)?.try_get(key).await
+    }
+
+    pub async fn try_put_on_shard(
+        &self,
+        shard_id: u16,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> ShardEngineResult<()> {
+        self.declared_shard(shard_id)?.try_put(key, value).await
+    }
+
+    pub async fn try_delete_on_shard(
+        &self,
+        shard_id: u16,
+        key: Vec<u8>,
+    ) -> ShardEngineResult<()> {
+        self.declared_shard(shard_id)?.try_delete(key).await
+    }
+
+    pub async fn try_apply_batch_on_shard(
+        &self,
+        shard_id: u16,
+        mutations: Vec<Mutation>,
+    ) -> ShardEngineResult<()> {
+        let shard_id = ShardId::new(shard_id)?;
+        let batch = ShardBatch::new(shard_id, mutations)?;
+        self.shards[shard_id.as_u16() as usize]
+            .try_apply_batch(batch)
+            .await
     }
 
     pub async fn get_many(&self, keys: &[Vec<u8>]) -> ShardEngineResult<Vec<Option<Vec<u8>>>> {
@@ -46,7 +96,10 @@ impl ShardStore {
         Ok(values)
     }
 
-    pub async fn set_many(&self, records: Vec<(Vec<u8>, Option<Vec<u8>>)>) -> ShardEngineResult<()> {
+    pub async fn set_many(
+        &self,
+        records: Vec<(Vec<u8>, Option<Vec<u8>>)>,
+    ) -> ShardEngineResult<()> {
         let mut by_shard: BTreeMap<u16, Vec<Mutation>> = BTreeMap::new();
         for (key, value) in records {
             let shard_id = shard_for_key(&key).as_u16();
@@ -59,13 +112,16 @@ impl ShardStore {
         for (shard_id, mutations) in by_shard {
             let shard_id = ShardId::new(shard_id)?;
             let batch = ShardBatch::new(shard_id, mutations)?;
-            self.shards[shard_id.as_u16() as usize].apply_batch(batch).await?;
+            self.shards[shard_id.as_u16() as usize]
+                .apply_batch(batch)
+                .await?;
         }
         Ok(())
     }
 
     pub async fn delete_many(&self, keys: Vec<Vec<u8>>) -> ShardEngineResult<()> {
-        self.set_many(keys.into_iter().map(|key| (key, None)).collect()).await
+        self.set_many(keys.into_iter().map(|key| (key, None)).collect())
+            .await
     }
 
     pub async fn metrics(&self) -> ShardEngineResult<ShardStoreMetrics> {
@@ -130,13 +186,37 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            store.get_many(&[key_a.clone(), key_b.clone()]).await.unwrap(),
+            store
+                .get_many(&[key_a.clone(), key_b.clone()])
+                .await
+                .unwrap(),
             vec![Some(b"one".to_vec()), Some(b"two".to_vec())]
         );
 
         store.delete_many(vec![key_a.clone()]).await.unwrap();
         assert_eq!(store.get(&key_a).await.unwrap(), None);
         assert_eq!(store.get(&key_b).await.unwrap(), Some(b"two".to_vec()));
+        store.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn declared_shard_primitives_reject_wrong_shard_before_admission() {
+        let store = ShardStore::spawn(8);
+        let key = b"declared-shard".to_vec();
+        let actual = shard_for_key(&key).as_u16();
+        let wrong = (actual + 1) % LOGICAL_SHARD_COUNT;
+
+        assert!(matches!(
+            store.try_get_on_shard(wrong, &key).await,
+            Err(ShardEngineError::WrongShard { .. })
+        ));
+        assert!(matches!(
+            store
+                .try_put_on_shard(wrong, key.clone(), b"value".to_vec())
+                .await,
+            Err(ShardEngineError::WrongShard { .. })
+        ));
+        assert_eq!(store.get(&key).await.unwrap(), None);
         store.shutdown().await.unwrap();
     }
 
@@ -154,7 +234,10 @@ mod tests {
             .await
             .unwrap();
 
-        let metrics = store.shards[shard.as_u16() as usize].metrics().await.unwrap();
+        let metrics = store.shards[shard.as_u16() as usize]
+            .metrics()
+            .await
+            .unwrap();
         assert_eq!(metrics.key_count, 2);
         assert_eq!(metrics.applied_mutations, 2);
         store.shutdown().await.unwrap();


### PR DESCRIPTION
Implements Accepted Spec 0004 M2-T3 only.

- adds a narrow compact request/response adapter over the verified M1 `ShardStore`
- recomputes/validates declared shard IDs from raw keys before admission
- prevalidates single-shard BATCH membership and rejects cross-shard batches before application
- maps M1 `QueueFull`, `Closed`, wrong-shard, malformed batch and owner-stop outcomes to frozen compact statuses
- uses fast-fail bounded shard admission for the compact foreground path
- keeps routing authority abstract/advisory; no Raft leadership or placement authority is introduced
- adds GET/SET/DELETE/BATCH, wrong-shard, cross-shard, advisory-not-owner and status-translation tests

Explicitly excludes T4 server integration, observability, benchmarking, consensus, WAL/snapshots and M3+ behavior.

Tracks #27.