### PR TITLE
spec: gate M2 depth-32 pipeline cliff before verification

### DIFF
--- a/specs/0004-compact-data-plane/requirements.md
+++ b/specs/0004-compact-data-plane/requirements.md
@@ -89,14 +89,24 @@ M2 excludes OpenRaft, WAL/snapshots, distributed placement/reconfiguration, leas
 
 ## 9. Performance and observability
 
-**REQ-M2-PERF-001** — The compact path SHOULD reduce healthy local request overhead relative to the existing gRPC path under equivalent M1 semantics; no fixed speedup is required for acceptance unless amended before verification.
+**REQ-M2-PERF-001** — The compact path SHOULD reduce healthy local request overhead relative to the existing gRPC path under equivalent M1 semantics; no fixed compact-vs-gRPC speedup is required for acceptance unless amended before verification.
 
 **REQ-M2-PERF-002** — Benchmark evidence MUST include GET/SET/DELETE and a mixed workload, at least 1 and 32 pipeline depth, p50/p95/p99, throughput, failures, payload sizes, and host/toolchain metadata.
 
 **REQ-M2-PERF-003** — Benchmark comparisons MUST use equivalent local consistency/durability semantics and MUST retain the existing gRPC path as the comparison point.
 
+**REQ-M2-PERF-004** — Before Spec 0004 may become Verified, the compact depth-32 path MUST NOT retain the repeatable transport cliff observed in M2-T6. On the frozen 16B-key/64B-value/50k-key local matrix, for every GET/SET/DELETE/80-20 workload the median compact depth-32 throughput across three complete runs MUST be at least the corresponding compact depth-1 throughput, with zero benchmark failures. This is a pipeline-health regression gate, not a public performance claim and not a license to weaken any bound, ordering, cancellation, consistency, or durability semantic.
+
+**REQ-M2-PERF-005** — Any transport tuning used to satisfy `REQ-M2-PERF-004` MUST be explicitly configured or deterministic, exercised on both accepted server and benchmark-client paths as applicable, and verified not to bypass per-connection in-flight limits, bounded response buffering, shard backpressure, or admitted-work cancellation semantics.
+
 **REQ-M2-OPS-001** — The server MUST expose counters/gauges sufficient to observe accepted/rejected frames, active connections, in-flight requests, protocol errors, overload responses, and bytes read/written.
 
 ## 10. Acceptance
 
-Spec 0004 may become Verified only when the implementation and tests establish all mandatory protocol, bound, pipelining, routing, backpressure, compatibility, and observability requirements and retain reproducible benchmark evidence. Passing M2 MUST NOT be interpreted as proving distributed linearizability or durable replicated writes; those belong to M3+.
+Spec 0004 may become Verified only when the implementation and tests establish all mandatory protocol, bound, pipelining, routing, backpressure, compatibility, observability, and pipeline-health requirements and retain reproducible benchmark evidence. Passing M2 MUST NOT be interpreted as proving distributed linearizability or durable replicated writes; those belong to M3+.
+
+## 11. Accepted amendment — depth-32 pipeline cliff
+
+M2-T6 retained a repeatable compact depth-32 result of roughly 40.9 ms p50 / 779 ops/s while compact depth 1 sustained roughly 11.2k ops/s and gRPC depth 32 sustained roughly 20–22k ops/s. Because this contradicts the intended healthy pipelined data-plane behavior, verification is intentionally blocked until the cause is diagnosed and corrected under `REQ-M2-PERF-004/005`.
+
+The approximately 40 ms signature is consistent with a small-write TCP delayed-ACK/Nagle interaction, and the current compact benchmark/server paths do not explicitly configure `TCP_NODELAY`; this is a hypothesis to test, not an implementation mandate. A fix MUST remain bounded to transport/pipeline mechanics and MUST NOT weaken the verified M1 semantics or M2 resource bounds.

--- a/specs/0004-compact-data-plane/tasks.md
+++ b/specs/0004-compact-data-plane/tasks.md
@@ -75,7 +75,7 @@ Prerequisite: M2-T2/T3.
 
 ## M2-T6 — Repeated comparative benchmark
 
-Requirements: `REQ-M2-PERF-*`
+Requirements: `REQ-M2-PERF-001/002/003`
 
 - compact client benchmark harness
 - equivalent gRPC comparison path
@@ -89,13 +89,30 @@ Completion: reproducible comparative evidence exists; conclusions explicitly sta
 
 Prerequisite: M2-T4/T5.
 
+## M2-T6A — Diagnose and correct compact depth-32 transport cliff
+
+Requirements: `REQ-M2-PERF-004/005`, plus preservation of `REQ-M2-BOUND-004`, `REQ-M2-PIPE-*`, and `REQ-M2-BP-*`
+
+- reproduce the retained T6 depth-32 cliff with exact benchmark semantics before changing transport behavior
+- instrument or otherwise isolate client write/read, server read/admission/handler, and response-write timing sufficiently to classify the stall
+- test the leading TCP small-write delayed-ACK/Nagle hypothesis, including explicit `TCP_NODELAY` configuration where appropriate, without assuming it is the root cause
+- apply only the smallest transport/pipeline correction supported by evidence
+- keep per-connection in-flight admission, active request-ID bounds, bounded response buffering, shard `QueueFull`/`Closed` propagation, same-shard ordering, and accepted-work cancellation semantics unchanged
+- add deterministic regression coverage for the chosen transport behavior where practical
+- rerun three complete comparative benchmark repetitions on one exact commit
+
+Completion: all Rust/M0 regression gates remain green, zero benchmark failures are retained, and for each frozen workload the median compact depth-32 throughput is at least its compact depth-1 throughput. Record before/after evidence and root-cause confidence without converting local engineering measurements into public release claims.
+
+Prerequisite: M2-T6 and this amendment merged in Accepted state.
+
 ## M2-T7 — Verification handoff
 
 - execute `verification.md` matrix
 - record exact commits, CI/workflow runs and benchmark artifacts
 - document compatibility surface (magic/version/op/status values)
 - separate correctness evidence from performance observations
+- include the M2-T6A root-cause/fix evidence and pipeline-health gate result
 - move Spec 0004 to Verified only when every mandatory gate passes
 - close #27 and unblock M3 only after verification merge
 
-Prerequisite: M2-T1..T6.
+Prerequisite: M2-T1..T6A.

--- a/specs/0004-compact-data-plane/verification.md
+++ b/specs/0004-compact-data-plane/verification.md
@@ -16,6 +16,7 @@
 | REQ-M2-BP-001..004 | saturated shard, slow reader/writer, queue bound and disconnect tests |
 | REQ-M2-COMPAT-001..003 | gRPC regression suite plus adapter/source review |
 | REQ-M2-PERF-001..003 | repeated compact-vs-gRPC benchmark under equivalent M1 semantics |
+| REQ-M2-PERF-004/005 | before/after depth-32 pipeline diagnosis plus three-run compact pipeline-health gate |
 | REQ-M2-OPS-001 | metric state-transition tests |
 
 ## V1 — Wire compatibility
@@ -106,6 +107,19 @@ Primary cells:
 
 Report median and run spread. Do not select only the fastest repetition. Any claimed speedup must compare equivalent M1 local semantics and must be labeled as a local data-plane engineering result, not durable replicated performance.
 
+## V9 — Depth-32 pipeline health
+
+M2-T6 established a repeatable compact depth-32 cliff (~40.9 ms p50 / ~779 ops/s) that is incompatible with calling the compact path healthy under pipelining. Before verification:
+
+- preserve the original T6 artifact and measurements unchanged as the before-state;
+- classify the stall using bounded diagnostics; the ~40 ms shape and lack of explicit `TCP_NODELAY` make delayed-ACK/Nagle interaction a leading hypothesis, not a pre-decided fix;
+- prove any correction does not bypass the in-flight semaphore, active request-ID tracking, bounded response channel, shard admission/backpressure, or M1 cancellation/order semantics;
+- capture three complete post-fix repetitions from one exact commit with the same frozen T6 matrix;
+- require zero benchmark failures;
+- for GET, SET, DELETE and 80/20 independently, require median compact depth-32 throughput >= median compact depth-1 throughput.
+
+This gate establishes that request pipelining is not pathologically serialized by transport mechanics. It is not a public speed claim and does not require compact to beat gRPC at depth 32.
+
 ## M2 acceptance checklist
 
 Spec 0004 becomes Verified only when all mandatory items are checked:
@@ -121,7 +135,8 @@ Spec 0004 becomes Verified only when all mandatory items are checked:
 - [ ] explicit overload/closed/routing/protocol statuses verified
 - [ ] existing gRPC compatibility path remains green
 - [ ] protocol metrics verified
-- [ ] 3-run compact-vs-gRPC benchmark evidence retained
+- [ ] original 3-run compact-vs-gRPC benchmark evidence retained
+- [ ] depth-32 pipeline-health regression gate passes on 3 post-fix runs
 - [ ] no OpenRaft/WAL/Multi-Raft/lease-read code mixed into M2
 
 Only after this verification PR merges may #27 close and M3 become unblocked.


### PR DESCRIPTION
Amends Accepted Spec 0004 before any semantic implementation change.

Verification of M2-T6 found a repeatable compact depth-32 cliff (~40.9 ms p50 / ~779 ops/s) while depth 1 sustains ~11.2k ops/s and gRPC depth 32 sustains ~20–22k ops/s. This PR does not change runtime code. It:

- adds REQ-M2-PERF-004/005 as a mandatory pipeline-health regression gate
- adds bounded M2-T6A to diagnose and correct the cliff before verification
- records the delayed-ACK/Nagle/TCP_NODELAY explanation as a leading hypothesis, not a mandated fix
- requires preservation of in-flight bounds, response bounds, shard backpressure, same-shard ordering, and cancellation semantics
- extends M2 verification so T7 cannot mark Spec 0004 Verified until three post-fix runs show depth-32 compact throughput >= compact depth-1 for each frozen workload with zero failures

No M0 baseline changes. No M3/consensus/WAL scope.