### PR TITLE
m2: correct compact TCP small-write pipeline stall

### DIFF
--- a/src/bin/hkvm2bench.rs
+++ b/src/bin/hkvm2bench.rs
@@ -366,6 +366,9 @@ async fn run_compact_case(
     let mut stream = TcpStream::connect(&config.compact_endpoint)
         .await
         .with_context(|| format!("failed to connect to {}", config.compact_endpoint))?;
+    stream
+        .set_nodelay(true)
+        .context("failed to enable TCP_NODELAY for compact benchmark connection")?;
     let limits = CodecLimits::default();
     let mut request_id = 1u64;
     run_compact_operations(
@@ -408,7 +411,7 @@ async fn run_compact_case(
         elapsed.as_nanos().min(u64::MAX as u128) as u64,
         config.compact_endpoint.clone(),
         environment,
-        "compact uses one TCP connection with true request pipelining and request-id response correlation",
+        "compact uses one TCP_NODELAY connection with true request pipelining and request-id response correlation",
     ))
 }
 

--- a/src/data_plane_runtime.rs
+++ b/src/data_plane_runtime.rs
@@ -268,6 +268,7 @@ pub async fn serve_listener_with_metrics<H: RequestHandler>(
     let runtime_limits = runtime_limits.validate()?;
     loop {
         let (stream, _) = listener.accept().await?;
+        stream.set_nodelay(true)?;
         let handler = handler.clone();
         let metrics = metrics.clone();
         tokio::spawn(async move {


### PR DESCRIPTION
Implements Accepted Spec 0004 M2-T6A only.

- explicitly enables TCP_NODELAY on every accepted compact server TcpStream
- explicitly enables TCP_NODELAY on the compact comparative benchmark client connection
- preserves all existing M2 in-flight admission, active request-ID bounds, bounded response buffering, shard backpressure, ordering, and cancellation semantics
- makes no changes to gRPC semantics, routing authority, consensus, WAL/snapshots, or M3+ behavior

This is the smallest evidence-supported correction for the retained ~40.9 ms depth-32 small-write stall. The existing three-run M2 comparative workflow remains the mandatory acceptance gate: zero failures and median compact depth-32 throughput >= corresponding compact depth-1 throughput for GET/SET/DELETE/80-20.

Tracks #27.