### PR TITLE
docs(sdd): accept Spec 0005 for M3 three-node OpenRaft

### DIFF
--- a/specs/0005-three-node-openraft/design.md
+++ b/specs/0005-three-node-openraft/design.md
@@ -1,0 +1,290 @@
+# Spec 0005 — One-Shard Three-Node OpenRaft Design
+
+- Status: Accepted
+- Requirements: `requirements.md`
+- Tracking issue: #38
+
+## 1. Architecture
+
+M3 introduces exactly one replicated HomeKV shard and deliberately keeps the M4 many-group problem out of scope.
+
+```text
+compact/gRPC ingress
+        |
+        v
+ replicated-shard adapter
+        |
+        +---- GET ----> OpenRaft safe read barrier ----> applied-state read
+        |
+        +-- mutation -> OpenRaft client_write
+                         |       |       |
+                         v       v       v
+                       node1   node2   node3
+                         |       |       |
+                      durable HomeKV Raft log/vote store
+                         |       |       |
+                         +--- committed entry -----------+
+                                      |
+                                      v
+                            HomeKV shard state machine
+```
+
+The compact M2 framing remains isolated from execution authority. The M3 adapter replaces local-only authority for the replicated shard without changing the frozen compact wire format.
+
+## 2. OpenRaft pin and owned boundaries
+
+M3 pins `openraft = "=0.9.25"`. The stable 0.9 line is selected rather than a 0.10 alpha, and the exact patch is frozen because OpenRaft documents pre-1.0 API instability.
+
+HomeKV defines a dedicated Raft type configuration with stable `u64` node IDs and application-owned command/response, node metadata, entry, snapshot-data, async runtime, and responder types as required by OpenRaft 0.9.25.
+
+HomeKV owns:
+
+- log/vote persistence and durable flush scheduling;
+- state-machine application and membership tracking;
+- snapshot bytes, metadata, integrity and atomic install;
+- Raft RPC transport/connection limits;
+- client routing/error translation;
+- metrics translation;
+- all database semantics.
+
+No OpenRaft type becomes part of HomeKV's public data-plane compatibility contract.
+
+## 3. Command model
+
+The replicated application command is deterministic and contains only logical operation data required by the state machine:
+
+```text
+Command::Set { key, value }
+Command::Delete { key }
+Command::Batch { mutations: [Set|Delete, ...] }
+```
+
+M2 `request_id` remains correlation metadata and is not used as an exactly-once token. Cross-shard batches remain rejected before Raft admission.
+
+Raft membership/blank entries are handled according to OpenRaft entry semantics and never decoded as HomeKV commands.
+
+Application responses map to the existing HomeKV result vocabulary. A committed SET/DELETE/BATCH response becomes externally successful only after the durable/apply boundary described below.
+
+## 4. State-machine adapter
+
+The M3 state machine wraps a single M1-compatible logical shard state image and serializes committed application through OpenRaft's `RaftStateMachine::apply` contract.
+
+For each applied entry it updates:
+
+1. last-applied log identity;
+2. membership metadata when the entry is membership-bearing;
+3. HomeKV application state for normal commands;
+4. the corresponding application response.
+
+The state-machine lock/owner boundary must permit a coherent snapshot point. No client mutation can directly modify the replicated shard state outside committed `apply`.
+
+The M1 local `ShardStore` remains available for its verified tests and non-M3 local code paths, but the M3 replicated adapter is the only authority for the M3 shard.
+
+## 5. Durable log storage
+
+M3 implements the split OpenRaft storage API (`RaftLogStorage` + `RaftStateMachine`) instead of the deprecated monolithic storage API.
+
+### 5.1 Persistent records
+
+The first M3 durable store uses a simple correctness-first append-oriented format with explicit record envelope:
+
+```text
+magic | format_version | record_kind | payload_len | payload | checksum
+```
+
+Record kinds cover at least vote, Raft entry, truncation/purge metadata as required by the chosen representation, committed-progress metadata if used for restart reconstruction, and snapshot metadata/pointer state.
+
+The implementation may use separate files for vote metadata and log segments if that makes atomic replacement/flush behavior clearer. Format details that affect recovery are frozen in implementation tests before M3 verification.
+
+### 5.2 Flush contract
+
+OpenRaft 0.9.25 requires `save_vote()` to persist the vote before returning. HomeKV therefore writes the new vote representation and performs the configured durable flush before reporting success.
+
+For `append(entries, LogFlushed)`, HomeKV:
+
+1. validates ordering/no-hole constraints;
+2. appends encoded records to the in-process/log-file state;
+3. returns from the async append once entries are readable through the log reader, as OpenRaft permits;
+4. schedules/executes the durable flush;
+5. invokes `LogFlushed` only after the OS durable operation succeeds for the relevant bytes/metadata;
+6. surfaces I/O failure without firing a false durable-success callback.
+
+A follower is counted by Raft toward durable replicated progress only according to OpenRaft's persisted-log callback protocol. HomeKV does not synthesize acknowledgement ahead of that callback.
+
+### 5.3 Truncate and purge
+
+Truncate/purge must be crash-safe enough that restart yields one coherent hole-free logical log. M3 favors a simple serialized metadata/update path over aggressive reclamation. Advanced segment recycling belongs to M5.
+
+## 6. Write path and acknowledgement
+
+Mutation flow:
+
+1. ingress validates frame, key/shard mapping and bounds as in M2;
+2. replicated adapter verifies the request targets the M3 shard;
+3. request is submitted to OpenRaft's client-write API;
+4. OpenRaft establishes current leader authority and replicates the entry;
+5. HomeKV storage callbacks certify durable persistence only at the accepted disk boundary;
+6. OpenRaft commits and invokes state-machine application;
+7. leader returns the state-machine response after its local apply completes;
+8. HomeKV translates leader-forward/not-leader/fatal/storage errors to safe existing statuses.
+
+The implementation must test the actual OpenRaft callback/completion ordering instead of assuming `client_write` alone proves HomeKV's durability semantics.
+
+## 7. Linearizable GET
+
+M3 uses OpenRaft 0.9.25's quorum-backed read mechanism. The default implementation calls `ensure_linearizable().await` or an equivalent composition of `get_read_log_id()` plus an applied-index wait.
+
+Only after the barrier succeeds and local applied progress reaches the required log position does HomeKV read the in-memory state.
+
+Follower-local strong reads and lease-only shortcuts are disabled. A non-leader returns a safe routing/not-owner result rather than reading stale state.
+
+## 8. Three-node formation
+
+The M3 verification topology is fixed to three voters with node IDs 1, 2, and 3 by default in deterministic tests. Node endpoints are explicit configuration.
+
+One bootstrap coordinator attempts OpenRaft initialization with the complete initial three-node membership. Initialization is treated as an idempotent cluster-formation operation: already-initialized responses are reconciled with the expected cluster identity/membership; incompatible bootstrap identity fails closed.
+
+M3 does not implement a general placement service. The three-node membership is configuration for one group only.
+
+## 9. Raft network adapter
+
+The network layer implements the RPCs required by OpenRaft 0.9.25, including vote, append entries/heartbeats, and snapshot transfer.
+
+Production/local runtime transport may initially use a dedicated internal RPC codec rather than reuse the public compact data plane. The critical design requirements are:
+
+- one bounded connection pool/endpoint state per peer;
+- bounded outstanding RPCs and snapshot-transfer buffers;
+- explicit connect/request deadlines;
+- transport errors returned to OpenRaft unchanged in meaning;
+- no authority inferred from transport/gossip state.
+
+Tests use an in-process deterministic transport facade with per-link drop/partition/delay switches. The facade exercises the same OpenRaft network abstraction and is never a separate consensus implementation.
+
+## 10. Snapshot model
+
+Snapshot bytes encode a coherent image of:
+
+- format/version;
+- logical shard ID;
+- last applied log identity;
+- stored membership;
+- complete key/value state;
+- integrity metadata.
+
+Snapshot building obtains a coherent state-machine view. The first implementation may copy one M3 shard to build the snapshot; avoiding that copy is an optimization, not a correctness prerequisite.
+
+Installation is staged:
+
+1. receive into a bounded temporary object/file;
+2. validate envelope, version, length and checksum;
+3. decode full state plus metadata;
+4. atomically swap the HomeKV state-machine image and snapshot pointer under the state-machine ownership boundary;
+5. only then expose the installed applied/membership position;
+6. remove obsolete snapshot state when safe.
+
+Crash-safe snapshot-file replacement uses temp-write + durable flush + atomic rename + parent-directory sync where filesystem semantics require it. M5 may optimize layout but not weaken this boundary.
+
+## 11. Recovery
+
+On process start:
+
+1. validate durable vote/log metadata and latest complete snapshot;
+2. restore snapshot state if present;
+3. expose the correct last-applied and membership metadata to OpenRaft;
+4. make valid post-snapshot durable logs readable;
+5. let OpenRaft restore/reconcile committed state and apply only justified committed entries;
+6. join elections/replication only after storage/state-machine initialization succeeds.
+
+Corruption, holes, impossible log ordering, or incompatible versions are startup errors. HomeKV never silently truncates unknown corruption and serves traffic.
+
+## 12. Backpressure and cancellation
+
+The M2 connection in-flight bound remains intact. The replicated adapter adds a separate configured bound for client writes/reads awaiting Raft completion.
+
+Raft network pools and per-peer outstanding work are bounded. Snapshot transfer has explicit chunk/buffer bounds.
+
+Once a mutation is admitted to OpenRaft, client disconnect does not cancel Raft commitment/application. Before admission, normal request cancellation may prevent submission. This preserves the established retry model.
+
+## 13. Failure behavior
+
+### Leader isolation
+
+A former leader isolated from both peers cannot form a quorum and therefore cannot durably commit/acknowledge new writes. Its uncommitted suffix may later be overwritten through normal Raft reconciliation.
+
+### One-node failure
+
+Two healthy voters retain quorum, elect/retain a leader, and continue strong operations subject to configured timeouts.
+
+### Quorum loss
+
+Strong reads/writes fail or remain pending only within bounded request deadlines; no fallback to local stale reads or local writes occurs.
+
+### Storage failure
+
+Vote/log flush errors surface as storage/fatal errors into OpenRaft and HomeKV health. They never trigger success callbacks.
+
+## 14. Observability
+
+HomeKV consumes OpenRaft metrics/watch state but translates it to stable database-oriented fields:
+
+- node/replica ID and role;
+- leader ID;
+- vote/term-equivalent identity;
+- last log, committed and applied positions;
+- replication progress/lag per peer;
+- membership;
+- snapshot state;
+- election/leadership-change counters;
+- Raft RPC failures/latency;
+- durable append/flush latency and errors;
+- state-machine apply latency;
+- admission/network queue depth and rejections.
+
+## 15. Test architecture
+
+A deterministic three-node harness owns three independent durable directories, clocks/timeouts where injectable, network link controls, and client helpers. It must be able to:
+
+- wait for exactly one leader;
+- partition arbitrary directed/bidirectional links;
+- kill/restart a node preserving disk state;
+- inspect committed/applied progress;
+- force enough log growth to exercise snapshot transfer;
+- capture operation histories for a linearizability checker.
+
+Fault tests assert state/history invariants, not merely sleep-based expectations.
+
+## 16. Alternatives
+
+### Memory-only OpenRaft store
+
+Rejected for M3 verification because Spec 0001 requires durable replicated acknowledgements.
+
+### `raft-rs::RawNode`
+
+Rejected by the parent accepted spec for M3. It remains an escape option only through a future accepted amendment if the M4 scaling gate justifies it.
+
+### OpenRaft 0.10 alpha
+
+Rejected for the first M3 implementation because 0.9.25 is the latest stable 0.9 release at spec acceptance; M3 values a reproducible stable integration baseline over alpha API churn.
+
+### Lease reads
+
+Deferred because M3 first proves quorum-backed linearizable reads without relying on timing/lease assumptions.
+
+### Reusing gossip for elections
+
+Rejected. Gossip is advisory only; Raft membership and leadership are authoritative.
+
+## 17. Requirement mapping
+
+- `REQ-M3-RAFT-*` -> sections 2, 9
+- `REQ-M3-SM-*` -> sections 3–4
+- `REQ-M3-WRITE-*` -> sections 6, 12–13
+- `REQ-M3-DUR-*` -> sections 5, 11
+- `REQ-M3-READ-*` -> section 7
+- `REQ-M3-MEM-*` -> section 8
+- `REQ-M3-NET-*` -> sections 9, 12
+- `REQ-M3-SNAP-*` -> sections 10–11
+- `REQ-M3-FAIL-*` -> section 13
+- `REQ-M3-OPS-*` -> section 14
+- `REQ-M3-PERF-*` -> correctness-first boundaries throughout; benchmarks in tasks/verification

--- a/specs/0005-three-node-openraft/requirements.md
+++ b/specs/0005-three-node-openraft/requirements.md
@@ -1,0 +1,169 @@
+# Spec 0005 — One-Shard Three-Node OpenRaft Requirements
+
+- Status: Accepted
+- Parent: `specs/0001-homekv-v1/requirements.md`
+- Tracking issue: #38
+
+## 1. Purpose
+
+M3 proves the first distributed HomeKV shard: one logical shard replicated across exactly three voting nodes using OpenRaft, with leader-authoritative writes, quorum-backed linearizable reads, explicit durable acknowledgement, failover, restart/recovery, and snapshot transfer sufficient to establish the correctness boundary before M4 scales the design to many Raft groups.
+
+M3 MUST preserve the Verified M0/M1/M2 contracts. Performance work MUST NOT weaken consistency, durability, backpressure, routing, or admitted-work semantics.
+
+## 2. Scope
+
+M3 covers:
+
+- exactly one HomeKV logical shard replicated by three voting replicas;
+- OpenRaft 0.9.25 pinned exactly for the first implementation;
+- HomeKV-owned Raft command/response types, log storage, state machine, network adapter, snapshot encoding/install path, and database-oriented observability;
+- deterministic three-node bootstrap for tests and local deployments;
+- strongly consistent SET/PUT, DELETE, deterministic single-shard BATCH, and GET;
+- quorum-durable mutation acknowledgement plus leader-local application;
+- safe linearizable reads through OpenRaft's quorum-backed read barrier;
+- stale/non-leader rejection or redirect without executing a write outside Raft authority;
+- leader failover, minority isolation, process restart, log replay, and snapshot installation/recovery;
+- bounded foreground admission and bounded Raft transport queues.
+
+M3 excludes:
+
+- 1,024-shard placement and Multi-Raft scheduling (M4);
+- online shard movement/rebalancing (M4);
+- lease-based read optimization;
+- relaxed/memory-only distributed durability;
+- cross-shard transactions;
+- public release benchmark claims;
+- advanced WAL/group-commit tuning beyond what is required to prove the durable boundary;
+- production TLS/authentication policy.
+
+## 3. Consensus dependency and compatibility
+
+**REQ-M3-RAFT-001** — M3 MUST use OpenRaft `=0.9.25`; Cargo resolution MUST NOT float to another OpenRaft minor/patch during M3 verification. Any version change requires an accepted Spec 0005 amendment because OpenRaft documents its pre-1.0 API as unstable.
+
+**REQ-M3-RAFT-002** — HomeKV MUST own its `RaftTypeConfig`, application command/response types, `RaftLogStorage`, `RaftStateMachine`, snapshot format, Raft network adapter/factory, connection management, durability boundary, observability mapping, and request routing integration. OpenRaft is the consensus engine, not HomeKV's database contract.
+
+**REQ-M3-RAFT-003** — M3 MUST NOT introduce a second consensus implementation or bypass OpenRaft ordering/leadership for foreground strongly consistent operations.
+
+## 4. Replicated state machine
+
+**REQ-M3-SM-001** — A client mutation accepted for the replicated shard MUST be represented as a deterministic Raft application command and applied only from committed Raft log entries.
+
+**REQ-M3-SM-002** — The state machine MUST preserve M1 SET, DELETE, and deterministic single-shard BATCH semantics, including batch atomicity and deterministic delete-of-absent behavior.
+
+**REQ-M3-SM-003** — Application order MUST equal committed Raft log order. A committed application command MUST be applied at most once for a given log identity during one coherent state-machine history; restart/snapshot replay MUST reconstruct the same logical state.
+
+**REQ-M3-SM-004** — Membership entries MUST update the persisted/applied membership metadata required by OpenRaft and MUST NOT be interpreted as HomeKV data mutations.
+
+**REQ-M3-SM-005** — The state-machine adapter MUST expose the last applied log identity and current membership consistently with the state it serves.
+
+## 5. Write consistency and authority
+
+**REQ-M3-WRITE-001** — SET/PUT, DELETE, and BATCH MUST enter the replicated state machine through OpenRaft's leader-authoritative client-write path or the version-equivalent API.
+
+**REQ-M3-WRITE-002** — A non-leader or node that cannot establish current write authority MUST NOT apply or acknowledge the mutation locally. It MUST return a safe not-leader/stale-route/unavailable result, optionally with an advisory leader hint.
+
+**REQ-M3-WRITE-003** — A minority partition MUST NOT acknowledge successful strongly consistent writes.
+
+**REQ-M3-WRITE-004** — A successful mutation response MUST be emitted only after the command is committed by a quorum, every replica counted toward the durable quorum has completed the accepted persistent-log boundary for that entry, and the current leader has applied the committed entry locally.
+
+**REQ-M3-WRITE-005** — Client transport cancellation after successful Raft admission MUST NOT revoke a command that later commits; cancellation before admission MUST NOT cause application. Existing M1/M2 retry/idempotence semantics remain unchanged.
+
+## 6. Durable Raft storage
+
+**REQ-M3-DUR-001** — `save_vote()` MUST not return success until the vote is durable on disk, matching OpenRaft's storage correctness contract.
+
+**REQ-M3-DUR-002** — `append()` MUST make appended entries readable before returning and MUST signal OpenRaft's log-flushed callback only after the corresponding log bytes and required persistent metadata are durably flushed with `fdatasync`, `fsync`, or a verified equivalent.
+
+**REQ-M3-DUR-003** — Log append/truncate/purge operations MUST preserve a hole-free Raft log and MUST reject or surface storage corruption/I/O failure rather than silently continuing.
+
+**REQ-M3-DUR-004** — Raft log records and snapshot payloads MUST include integrity protection sufficient to detect corrupted/truncated persisted content before it is applied.
+
+**REQ-M3-DUR-005** — The durable log format MUST be versioned. Unknown incompatible format versions MUST fail closed during recovery.
+
+**REQ-M3-DUR-006** — Recovery MUST never expose an uncommitted/speculative log entry as applied HomeKV state.
+
+**REQ-M3-DUR-007** — If the in-memory state machine is not itself persisted on every apply, M3 MUST retain enough durable committed/snapshot/log metadata to reconstruct the state justified by committed Raft history after restart.
+
+## 7. Linearizable reads
+
+**REQ-M3-READ-001** — Default GET MUST be served by the authoritative leader only after a quorum-backed OpenRaft linearizability barrier (`ensure_linearizable()`, `get_read_log_id()` plus applied wait, or the version-equivalent safe API) succeeds.
+
+**REQ-M3-READ-002** — A GET MUST observe a state-machine applied position at least as new as the read barrier returned/established by OpenRaft before reading the key.
+
+**REQ-M3-READ-003** — Followers MUST NOT serve default GET from local state as if it were strongly consistent.
+
+**REQ-M3-READ-004** — Lease-only leader-local reads are forbidden in M3 even if OpenRaft exposes lease-related machinery.
+
+## 8. Three-node membership and bootstrap
+
+**REQ-M3-MEM-001** — M3's verified topology MUST contain exactly three voting nodes with stable node IDs and explicit Raft endpoints.
+
+**REQ-M3-MEM-002** — Cluster initialization MUST be deterministic and idempotent for the same bootstrap configuration; concurrent/repeated bootstrap attempts MUST NOT create split authoritative clusters.
+
+**REQ-M3-MEM-003** — Consensus membership is authoritative. Existing gossip/failure detection MAY provide health observations but MUST NOT grant leadership, mutate Raft membership, or authorize writes.
+
+**REQ-M3-MEM-004** — General online add/remove/rebalance flows are deferred to M4; M3 MAY exercise membership APIs only as required for safe initial formation and snapshot/follower catch-up tests.
+
+## 9. Network and backpressure
+
+**REQ-M3-NET-001** — HomeKV's Raft network adapter MUST implement the OpenRaft RPC surface required by the pinned version, including vote, append-entries, and snapshot transfer paths.
+
+**REQ-M3-NET-002** — Raft RPC connections and request queues MUST be bounded/configurable. Network failure or a slow replica MUST NOT cause unbounded memory growth.
+
+**REQ-M3-NET-003** — Transport failure MUST surface to OpenRaft as transport/RPC failure; it MUST NOT be converted into false success or local authority.
+
+**REQ-M3-NET-004** — Test transport MUST support deterministic partition/drop/delay controls sufficient for verification without altering consensus semantics.
+
+## 10. Snapshot and recovery
+
+**REQ-M3-SNAP-001** — Snapshot metadata MUST identify at least format version, last included/applied log identity, membership state, shard identity, payload length, and integrity checksum/digest.
+
+**REQ-M3-SNAP-002** — A snapshot MUST represent a coherent state-machine point. Snapshot creation MUST NOT expose a mixture of application positions.
+
+**REQ-M3-SNAP-003** — Snapshot installation MUST validate metadata/integrity before making the new state visible, then atomically replace the receiving state-machine image from HomeKV's perspective.
+
+**REQ-M3-SNAP-004** — A restarted or lagging replica MUST be able to recover from a valid snapshot plus subsequent durable Raft log state and rejoin without serving speculative state.
+
+**REQ-M3-SNAP-005** — Truncated/corrupted/incompatible snapshots MUST fail closed and MUST NOT be partially installed as authoritative state.
+
+## 11. Failure semantics
+
+**REQ-M3-FAIL-001** — Loss/isolation of the current leader MUST eventually allow the remaining healthy quorum to elect a new leader and resume strongly consistent operations.
+
+**REQ-M3-FAIL-002** — The isolated old leader MUST not acknowledge successful writes while unable to contact a quorum, and after reconnection its conflicting uncommitted suffix MUST not become applied application state.
+
+**REQ-M3-FAIL-003** — Loss of quorum MUST fail or block strongly consistent operations within configured request/election time bounds rather than silently degrading consistency.
+
+**REQ-M3-FAIL-004** — Restart of one replica after acknowledged durable writes MUST recover those writes when justified by the surviving committed replicated state.
+
+## 12. Operability
+
+**REQ-M3-OPS-001** — HomeKV MUST expose per-replica database-oriented state sufficient to inspect node ID, role, current leader, vote/term-equivalent identity, last log, committed progress, applied progress, membership, snapshot state, and replica health.
+
+**REQ-M3-OPS-002** — Counters/histograms MUST cover client write/read outcomes, not-leader/unavailable responses, elections/leadership changes, Raft RPC failures, replication lag/progress, WAL append/flush latency, snapshot build/install, queue/backpressure, and recovery failures.
+
+**REQ-M3-OPS-003** — Public HomeKV management/metrics types MUST NOT expose OpenRaft-specific Rust types as a compatibility contract.
+
+## 13. Performance constraints
+
+**REQ-M3-PERF-001** — M3 benchmarks are engineering evidence only. They MUST state replication factor 3, linearizable-read mode, durable-write mode, workload, payload sizes, concurrency, host/toolchain, p50/p95/p99, throughput, and failures.
+
+**REQ-M3-PERF-002** — No M3 optimization may acknowledge before `REQ-M3-WRITE-004`, bypass the safe read barrier, create unbounded queues, or weaken verified M0/M1/M2 behavior.
+
+**REQ-M3-PERF-003** — Group commit, lease reads, Multi-Raft coalescing, and other semantic/performance optimizations require the milestone/spec that explicitly owns them.
+
+## 14. Verification acceptance
+
+Spec 0005 may become Verified only when retained automated evidence establishes all mandatory requirements, including at minimum:
+
+1. deterministic state-machine command tests and three-node replicated CRUD/batch tests;
+2. explicit persistence-boundary tests proving vote durability and log-flush callback ordering;
+3. leader isolation/minority-write rejection and new-leader failover tests;
+4. linearizable-read histories under concurrent writes and leadership change, checked by a model/history checker rather than timing assertions alone;
+5. restart/replay tests after acknowledged writes;
+6. snapshot build/install/catch-up plus corruption/truncation rejection tests;
+7. bounded-network/backpressure tests;
+8. preservation of all required M0/M1/M2 CI gates;
+9. a three-run replicated engineering benchmark with all semantics recorded.
+
+Passing M3 proves one replicated shard. It MUST NOT be interpreted as proving M4's 1,024-group placement/scaling behavior or public release performance.

--- a/specs/0005-three-node-openraft/tasks.md
+++ b/specs/0005-three-node-openraft/tasks.md
@@ -1,0 +1,188 @@
+# Spec 0005 — One-Shard Three-Node OpenRaft Tasks
+
+- Status: Accepted
+- Requirements: `requirements.md`
+- Design: `design.md`
+- Tracking issue: #38
+
+Each task is a bounded implementation/review slice. No task may silently change Spec 0005 semantics; amend and re-accept the spec first.
+
+## M3-S0 — Accept the child spec
+
+Requirements: all
+
+Completion criteria:
+
+- requirements, design, tasks, and verification plan are reviewed together;
+- OpenRaft version is pinned by the spec;
+- durability acknowledgement and read semantics are falsifiable;
+- M4/M5 boundaries are explicit;
+- CI preserves the Verified M0/M1/M2 baseline;
+- spec PR merges before any M3 semantic implementation.
+
+## M3-T1 — OpenRaft types + deterministic state-machine adapter
+
+Requirements: `REQ-M3-RAFT-001..003`, `REQ-M3-SM-001..005`
+
+Prerequisite: M3-S0
+
+Scope:
+
+- add exact `openraft = "=0.9.25"` dependency;
+- define HomeKV Raft type config, node metadata, deterministic command/response types;
+- implement the one-shard `RaftStateMachine` application boundary against M1-compatible state;
+- retain applied log identity and membership metadata;
+- add deterministic command/application tests.
+
+Must not include durable WAL, production Raft transport, cluster bootstrap, or serving replicated client traffic.
+
+Completion criteria:
+
+- all command variants deterministically apply in committed order;
+- membership entries do not mutate KV state;
+- repeated/recovery-oriented application tests establish stable logical state;
+- existing M0/M1/M2 gates pass.
+
+## M3-T2 — Durable Raft log/vote store
+
+Requirements: `REQ-M3-DUR-001..007`
+
+Prerequisite: M3-T1
+
+Scope:
+
+- implement versioned/checksummed log/vote persistence;
+- implement `RaftLogReader`/`RaftLogStorage` for the pinned API;
+- make append entries readable before append returns;
+- fire `LogFlushed` only after durable flush;
+- persist votes before `save_vote` returns;
+- implement hole-free truncate/purge and recovery validation;
+- retain committed-progress metadata if required by the chosen recovery construction.
+
+Must not introduce group-commit optimization beyond a simple correctness-first serialized flush path.
+
+Completion criteria:
+
+- crash/reopen tests for votes/logs/truncate/purge;
+- injected I/O failure never yields false flush success;
+- checksum/truncation/version corruption fails closed;
+- callback-ordering tests establish the accepted persistence boundary;
+- existing gates pass.
+
+## M3-T3 — Bounded three-node Raft transport and bootstrap
+
+Requirements: `REQ-M3-MEM-001..004`, `REQ-M3-NET-001..004`, parts of `REQ-M3-WRITE-001..003`
+
+Prerequisite: M3-T2
+
+Scope:
+
+- implement the OpenRaft network adapter/factory required by 0.9.25;
+- bounded per-peer connection/outstanding RPC behavior;
+- vote, append-entries/heartbeat, and snapshot RPC plumbing;
+- deterministic three-voter bootstrap for one shard;
+- test transport facade with link partition/drop/delay controls.
+
+Must not integrate 1,024-shard placement or general online rebalancing.
+
+Completion criteria:
+
+- exactly one leader emerges in healthy three-node tests;
+- repeated compatible bootstrap is safe/idempotent;
+- incompatible cluster identity/membership bootstrap fails closed;
+- link failures surface as Raft transport failures;
+- queue/resource bounds are tested;
+- existing gates pass.
+
+## M3-T4 — Replicated writes + linearizable GET
+
+Requirements: `REQ-M3-WRITE-001..005`, `REQ-M3-READ-001..004`, `REQ-M3-PERF-002`
+
+Prerequisite: M3-T3
+
+Scope:
+
+- route SET/DELETE/BATCH through leader-authoritative `client_write`;
+- hold external success until durable quorum commitment plus leader apply is established;
+- implement GET through `ensure_linearizable()` or the accepted equivalent barrier and applied wait;
+- translate not-leader/stale/unavailable/storage outcomes to the M2 result vocabulary;
+- preserve admitted-work cancellation and retry semantics.
+
+Must not enable lease reads or follower strong reads.
+
+Completion criteria:
+
+- three-node replicated CRUD/batch tests;
+- follower/stale-leader requests do not apply locally;
+- minority partition cannot acknowledge writes;
+- GET history is checked against a linearizable model under concurrent writes;
+- existing gates pass.
+
+## M3-T5 — Snapshot, failover, restart and recovery
+
+Requirements: `REQ-M3-SNAP-001..005`, `REQ-M3-FAIL-001..004`, remaining `REQ-M3-DUR-*`
+
+Prerequisite: M3-T4
+
+Scope:
+
+- coherent versioned/checksummed snapshot build;
+- bounded snapshot transfer/install;
+- atomic state-machine replacement on validated install;
+- restart from durable snapshot/log state;
+- leader kill/isolation/rejoin scenarios;
+- lagging follower catch-up via snapshot when needed.
+
+Must not add M5 storage-layout optimizations.
+
+Completion criteria:
+
+- acknowledged writes survive leader loss/restart subject to quorum assumptions;
+- healthy quorum elects a new leader and resumes;
+- old isolated leader cannot acknowledge writes;
+- corrupted/truncated/incompatible snapshot is rejected;
+- recovered state equals committed model state;
+- existing gates pass.
+
+## M3-T6 — Observability, bounded admission, fault matrix and engineering benchmark
+
+Requirements: `REQ-M3-OPS-001..003`, `REQ-M3-NET-002`, `REQ-M3-PERF-001..003`
+
+Prerequisite: M3-T5
+
+Scope:
+
+- expose HomeKV-oriented role/leader/log/commit/apply/membership/snapshot/replication signals;
+- metrics for reads/writes, errors, elections, RPCs, durable flush, apply, snapshots and queue/backpressure;
+- bounded foreground replicated-operation admission;
+- complete deterministic one-node/minority/quorum-loss/network fault matrix;
+- retained three-run engineering benchmark under RF=3 durable/linearizable semantics.
+
+Completion criteria:
+
+- saturation is bounded and observable;
+- metrics reflect tested state transitions without becoming a compatibility dependency on OpenRaft Rust types;
+- benchmark retains host/toolchain/workload/latency/throughput/failure evidence;
+- no benchmark result is presented as a release claim;
+- existing gates pass.
+
+## M3-T7 — Verification handoff
+
+Requirements: all mandatory Spec 0005 requirements
+
+Prerequisite: M3-T6
+
+Scope:
+
+- execute and retain the full requirement-to-evidence matrix in `verification.md`;
+- review every mandatory requirement independently;
+- confirm M0/M1/M2 regression gates still pass;
+- record exact tested commit, workflow runs/artifacts, toolchain and known residual risks;
+- change Spec 0005 state to Verified only if all mandatory gates pass.
+
+Completion criteria:
+
+- no unresolved mandatory requirement;
+- verification record is reproducible and traceable;
+- issue #38 is closed only after the verification PR merges;
+- v1 tracker #7 marks M3 Verified and identifies M4 spec acceptance as the next SDD boundary.

--- a/specs/0005-three-node-openraft/verification.md
+++ b/specs/0005-three-node-openraft/verification.md
@@ -1,0 +1,225 @@
+# Spec 0005 — One-Shard Three-Node OpenRaft Verification
+
+- Status: Accepted verification plan; implementation not yet verified
+- Requirements: `requirements.md`
+- Design: `design.md`
+- Tasks: `tasks.md`
+- Tracking issue: #38
+
+## 1. Verification rule
+
+M3 is Verified only when every mandatory requirement below has retained evidence on one exact implementation commit and the required repository regression gates pass. Timing-only distributed tests are insufficient for consistency claims; histories and persisted state must be checked against explicit invariants/models.
+
+The verified scope is exactly one logical shard replicated by three voters. Evidence MUST NOT be generalized to M4's many-group architecture or to public performance claims.
+
+## 2. Required environment record
+
+The M3 verification record must capture:
+
+- exact HomeKV commit SHA;
+- exact OpenRaft version and Cargo lock resolution;
+- Rust toolchain and target;
+- OS/kernel;
+- CPU and memory metadata;
+- filesystem used for durable tests;
+- three-node topology and endpoint configuration;
+- Raft election/heartbeat/request timeouts;
+- foreground/Raft network queue bounds;
+- benchmark key/value sizes, keyspace, concurrency and operation mix;
+- durability mode = quorum durable + leader apply;
+- read mode = quorum-backed linearizable;
+- replication factor = 3.
+
+## 3. Requirement-to-evidence matrix
+
+| Requirement | Required evidence | State |
+|---|---|---|
+| `REQ-M3-RAFT-001` | lockfile/dependency test shows exact OpenRaft 0.9.25 | Pending |
+| `REQ-M3-RAFT-002..003` | adapter boundary review + tests proving no direct strong mutation bypass | Pending |
+| `REQ-M3-SM-001..005` | deterministic apply/order/membership/applied-state unit + property tests | Pending |
+| `REQ-M3-WRITE-001..005` | replicated CRUD/batch, non-leader, minority, cancellation tests | Pending |
+| `REQ-M3-DUR-001` | vote crash/reopen and injected flush-failure tests | Pending |
+| `REQ-M3-DUR-002` | append readability + `LogFlushed` durability-order tests | Pending |
+| `REQ-M3-DUR-003..005` | truncate/purge/no-hole plus corruption/truncation/version tests | Pending |
+| `REQ-M3-DUR-006..007` | restart/replay model-state tests excluding uncommitted suffix | Pending |
+| `REQ-M3-READ-001..004` | safe-barrier integration + linearizable history checks + follower rejection | Pending |
+| `REQ-M3-MEM-001..004` | deterministic 3-voter bootstrap/repeat/incompatible-init tests | Pending |
+| `REQ-M3-NET-001..004` | RPC coverage, bounded queues and deterministic partition controls | Pending |
+| `REQ-M3-SNAP-001..005` | snapshot round-trip/install/catch-up/corruption/crash tests | Pending |
+| `REQ-M3-FAIL-001..004` | leader loss, old-leader isolation, quorum loss, restart tests | Pending |
+| `REQ-M3-OPS-001..003` | metrics/state assertions during role/failure/storage transitions | Pending |
+| `REQ-M3-PERF-001..003` | retained RF=3 durable/linearizable 3-run engineering benchmark | Pending |
+
+## 4. State-machine verification
+
+Tests must cover at minimum:
+
+1. SET replaces/creates exactly one key;
+2. DELETE of present and absent keys is deterministic;
+3. BATCH applies all mutations atomically in one committed entry;
+4. committed entries applied in log order yield the same model state;
+5. membership/blank entries never mutate KV data;
+6. last-applied identity advances consistently with application;
+7. snapshot restore plus subsequent committed entries yields the same model state as uninterrupted application.
+
+Property tests should generate command sequences and compare the HomeKV state machine against a simple reference map/batch model.
+
+## 5. Persistence-boundary verification
+
+### Vote durability
+
+Test sequence:
+
+1. persist vote A;
+2. wait for `save_vote()` success;
+3. simulate immediate process loss/reopen;
+4. assert vote A is recovered;
+5. inject write/flush failure and assert `save_vote()` returns failure and no success state is claimed.
+
+### Log-flush ordering
+
+Instrument the store with deterministic hooks:
+
+1. call append with entry E and capture `LogFlushed`;
+2. establish E is readable after append returns;
+3. hold the underlying durable-flush completion;
+4. assert callback has not fired;
+5. complete durable flush successfully;
+6. assert callback fires once;
+7. reopen storage and assert E is valid;
+8. repeat with injected flush failure and assert no false successful callback.
+
+### Corruption and holes
+
+Exercise:
+
+- truncated final record;
+- bit-corrupted payload/checksum;
+- unknown format version;
+- impossible record length;
+- invalid/hole-producing log sequence;
+- crash around truncate/purge metadata update.
+
+All must fail closed or recover to the last explicitly valid state allowed by the storage format; none may silently apply corrupt content.
+
+## 6. Three-node consensus verification
+
+Healthy-cluster tests must establish:
+
+- exactly one leader becomes authoritative;
+- writes submitted to the leader replicate and apply on all healthy replicas eventually;
+- application order is identical across replicas;
+- follower/non-leader strong mutations return safe failure/redirect and never mutate local application state directly;
+- one unavailable voter still permits the two-node quorum to make progress;
+- no test helper grants authority outside OpenRaft.
+
+## 7. Linearizability verification
+
+Use a model/history checker over operation intervals and results for concurrent GET/SET/DELETE (and deterministic batches where supported by the checker model).
+
+Mandatory histories:
+
+1. healthy leader with concurrent readers/writers;
+2. leader isolated during active operations, followed by a new leader;
+3. old leader reconnecting with an uncommitted suffix;
+4. one follower slow/delayed while quorum remains healthy.
+
+A GET result is accepted only if the completed operation history has a valid per-shard linearization respecting real-time precedence. Tests must also assert the implementation actually traverses the safe OpenRaft read barrier; a passing history by luck is not enough.
+
+Follower-local reads presented as default strong GET must be rejected by test.
+
+## 8. Failure matrix
+
+| Fault | Expected invariant |
+|---|---|
+| kill current leader | healthy quorum elects new leader; acknowledged state remains available |
+| isolate leader from both peers | isolated node cannot acknowledge new strong writes |
+| isolate one follower | remaining quorum continues safely |
+| split 1+2 | only 2-node side may make progress after election |
+| lose quorum | no successful strong write; no stale-read fallback |
+| heal partition | replicas converge; conflicting uncommitted suffix is not applied |
+| restart follower | catches up from log or snapshot without speculative state |
+| restart former leader | recovers durable state and rejoins under current consensus authority |
+| storage flush failure | affected operation does not receive false durable success |
+| corrupt log/snapshot | node fails closed rather than serving corrupt state |
+
+Tests should use explicit cluster-state predicates and bounded waits, not fixed sleeps as proof.
+
+## 9. Snapshot/recovery verification
+
+Mandatory scenarios:
+
+- build snapshot at a known applied position and round-trip contents/metadata;
+- continue writes while/after snapshot creation and confirm snapshot remains coherent;
+- install snapshot on a lagging replica and then catch up subsequent entries;
+- restart from snapshot + subsequent durable log and compare with committed reference state;
+- interrupt snapshot reception before completion and assert old state remains authoritative;
+- corrupt/truncate snapshot and assert install/restart rejection;
+- incompatible snapshot version fails closed;
+- exercise atomic replacement/crash boundary where the platform test harness permits.
+
+## 10. Backpressure and resource verification
+
+Tests must deliberately saturate:
+
+- foreground operations awaiting Raft;
+- per-peer Raft RPC capacity;
+- slow/unreachable peer transport;
+- snapshot transfer buffers.
+
+Evidence must show configured bounds are respected and saturation surfaces through backpressure/error/timeout without an unbounded queue. Existing M2 connection bounds remain active.
+
+## 11. Observability verification
+
+During deterministic transitions, assert HomeKV's exposed state changes coherently for:
+
+- follower/candidate/leader role;
+- leader ID;
+- log/commit/applied progress;
+- replication lag;
+- elections/leadership changes;
+- RPC failures;
+- durable flush latency/error;
+- snapshot build/install;
+- admission/transport saturation.
+
+Tests should verify HomeKV-owned representations rather than snapshot-testing OpenRaft internal Rust debug formats.
+
+## 12. Engineering benchmark gate
+
+M3-T6 retains three complete runs of an RF=3 configuration for at least:
+
+- GET;
+- SET;
+- DELETE;
+- 80/20 read/write mix;
+
+using documented key/value sizes and at least low and moderate client concurrency. Report p50/p95/p99, throughput and failures for each cell.
+
+This benchmark is a regression/engineering characterization. Spec 0005 does not impose a fixed speedup or latency number because the first M3 objective is proving the strong durable contract. Any later optimization must preserve the exact tested consistency/durability semantics.
+
+Zero benchmark failures are required for a run to count as retained evidence.
+
+## 13. Regression gates
+
+Every implementation/verification PR must run the repository's normal Rust CI and preserve the existing M0/M1/M2 required smoke/regression gates. M3 work must not rewrite the frozen M0 baseline or relax previously Verified assertions.
+
+Before the final verification PR:
+
+- M0 remains Verified and unchanged except non-semantic test harness maintenance if separately justified;
+- M1 shard semantics tests pass;
+- M2 codec/runtime/routing/pipeline tests pass;
+- the prior M2 pipeline-health regression remains passing where exercised by required CI.
+
+## 14. Final M3 verification record
+
+M3-T7 will replace `Pending` states with PASS/FAIL and record:
+
+- exact tested SHA;
+- PRs for T1–T6;
+- workflow run IDs and retained artifact IDs/digests;
+- requirement-specific test names/evidence;
+- three-run benchmark summary;
+- residual risks and explicitly deferred M4/M5 work.
+
+Only then may the spec status change to **Verified** and issue #38 close.


### PR DESCRIPTION
## Summary

Accept the M3 child spec before any M3 semantic implementation.

This adds `specs/0005-three-node-openraft/` with requirements, design, bounded task slices, and verification plan for exactly one 3-voter replicated shard.

### Accepted decisions

- pin OpenRaft exactly to `0.9.25` for M3;
- HomeKV owns log/vote persistence, state machine, Raft network adapter, snapshot format/install, routing/error translation and observability;
- durable mutation success requires quorum-durable Raft persistence plus current-leader application;
- default GET uses OpenRaft's quorum-backed linearizability barrier and applied-position wait;
- followers/minority partitions never silently serve/acknowledge strong operations;
- versioned/checksummed log and snapshot persistence fails closed on corruption/incompatible format;
- queues/Raft transport/snapshot buffering remain bounded;
- M4 Multi-Raft/1,024-shard placement, lease reads, relaxed durability and M5 optimization remain out of scope.

## Traceability

Parent: Spec 0001 `REQ-CONS-*`, `REQ-DUR-*`, `REQ-FAIL-*`, `REQ-RAFT-*`, `REQ-SDD-004`
Tracking: #38, umbrella #7
Task: M3-S0

## Verification for this PR

Spec-only. Required repository CI must pass and preserve all existing M0/M1/M2 gates before merge. No runtime semantics are changed by this PR.