### PR TITLE
m3: add OpenRaft types and deterministic state machine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ md-5 = "0.10.6"
 cool-id-generator = "1.0.1"
 structopt = "0.3.26"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-openraft = { version = "=0.9.25", features = ["serde"] }
+openraft = { version = "=0.9.25", features = ["serde", "storage-v2"] }
 
 [build-dependencies]
 tonic-build = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ md-5 = "0.10.6"
 cool-id-generator = "1.0.1"
 structopt = "0.3.26"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+openraft = { version = "=0.9.25", features = ["serde"] }
 
 [build-dependencies]
 tonic-build = "0.12.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod data_plane;
 pub mod data_plane_adapter;
 pub mod data_plane_runtime;
 pub mod honey_bees;
+pub mod raft;
 pub mod storage;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -289,7 +289,7 @@ mod tests {
         let view = sm.view().await;
         assert_eq!(view.data, before);
         assert_eq!(view.last_applied, Some(log_id(2)));
-        assert_eq!(view.membership.log_id(), Some(log_id(2)));
+        assert_eq!(view.membership.log_id(), &Some(log_id(2)));
     }
 
     #[tokio::test]

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
-use std::io;
+use std::io::{self, Cursor};
 use std::sync::Arc;
 
 use openraft::storage::{RaftSnapshotBuilder, RaftStateMachine, Snapshot, SnapshotMeta};

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -8,7 +8,7 @@ use openraft::{
     BasicNode, Entry, EntryPayload, LogId, OptionalSend, StorageError, StorageIOError,
     StoredMembership,
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 pub type RaftNodeId = u64;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use std::io;
 use std::sync::Arc;
 
-use openraft::storage::{RaftStateMachine, Snapshot};
+use openraft::storage::{RaftSnapshotBuilder, RaftStateMachine, Snapshot, SnapshotMeta};
 use openraft::{
-    BasicNode, Entry, EntryPayload, LogId, RaftSnapshotBuilder, SnapshotMeta, StorageError,
-    StorageIOError, StoredMembership,
+    BasicNode, Entry, EntryPayload, LogId, OptionalSend, StorageError, StorageIOError,
+    StoredMembership,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -96,7 +96,7 @@ impl HomeKvStateMachine {
     }
 
     fn storage_error(message: &'static str) -> StorageError<RaftNodeId> {
-        let err = io::Error::new(io::ErrorKind::InvalidData, message);
+        let err = io::Error::new(io::ErrorKind::Unsupported, message);
         StorageIOError::read_state_machine(&err).into()
     }
 
@@ -114,7 +114,6 @@ impl HomeKvStateMachine {
                 if mutations.is_empty() {
                     return RaftResponse::EmptyBatch;
                 }
-
                 for mutation in &mutations {
                     match mutation {
                         RaftMutation::Set { key, value } => {
@@ -141,7 +140,7 @@ impl RaftSnapshotBuilder<HomeKvRaftConfig> for DeferredSnapshotBuilder {
         &mut self,
     ) -> Result<Snapshot<HomeKvRaftConfig>, StorageError<RaftNodeId>> {
         Err(HomeKvStateMachine::storage_error(
-            "snapshot build is deferred to accepted M3-T5",
+            "snapshot build is deferred to M3-T5",
         ))
     }
 }
@@ -167,7 +166,8 @@ impl RaftStateMachine<HomeKvRaftConfig> for HomeKvStateMachine {
         entries: I,
     ) -> Result<Vec<RaftResponse>, StorageError<RaftNodeId>>
     where
-        I: IntoIterator<Item = Entry<HomeKvRaftConfig>> + Send,
+        I: IntoIterator<Item = Entry<HomeKvRaftConfig>> + OptionalSend,
+        I::IntoIter: OptionalSend,
     {
         let mut responses = Vec::new();
         let mut state = self.inner.write().await;
@@ -179,9 +179,7 @@ impl RaftStateMachine<HomeKvRaftConfig> for HomeKvStateMachine {
                     continue;
                 }
                 if entry.log_id.index <= last.index {
-                    return Err(Self::storage_error(
-                        "state-machine apply order regressed or reused a log index",
-                    ));
+                    return Err(Self::storage_error("state-machine apply order regressed"));
                 }
             }
 
@@ -193,11 +191,9 @@ impl RaftStateMachine<HomeKvRaftConfig> for HomeKvStateMachine {
                     RaftResponse::Noop
                 }
             };
-
             state.last_applied = Some(entry.log_id);
             responses.push(response);
         }
-
         Ok(responses)
     }
 
@@ -211,9 +207,7 @@ impl RaftStateMachine<HomeKvRaftConfig> for HomeKvStateMachine {
         Box<<HomeKvRaftConfig as openraft::RaftTypeConfig>::SnapshotData>,
         StorageError<RaftNodeId>,
     > {
-        Err(Self::storage_error(
-            "snapshot receiving is deferred to accepted M3-T5",
-        ))
+        Err(Self::storage_error("snapshot receive is deferred to M3-T5"))
     }
 
     async fn install_snapshot(
@@ -221,9 +215,7 @@ impl RaftStateMachine<HomeKvRaftConfig> for HomeKvStateMachine {
         _meta: &SnapshotMeta<RaftNodeId, RaftNode>,
         _snapshot: Box<<HomeKvRaftConfig as openraft::RaftTypeConfig>::SnapshotData>,
     ) -> Result<(), StorageError<RaftNodeId>> {
-        Err(Self::storage_error(
-            "snapshot installation is deferred to accepted M3-T5",
-        ))
+        Err(Self::storage_error("snapshot install is deferred to M3-T5"))
     }
 
     async fn get_current_snapshot(
@@ -252,171 +244,79 @@ mod tests {
         }
     }
 
-    fn membership(index: u64) -> Entry<HomeKvRaftConfig> {
-        let voters = BTreeSet::from([1, 2, 3]);
-        let membership = Membership::new(vec![voters], BTreeMap::<RaftNodeId, RaftNode>::new());
-        Entry {
-            log_id: log_id(index),
-            payload: EntryPayload::Membership(membership),
-        }
-    }
-
     #[tokio::test]
-    async fn applies_commands_in_committed_order_with_m1_semantics() {
-        let mut state_machine = HomeKvStateMachine::default();
-        let entries = vec![
-            normal(
-                1,
-                RaftCommand::Set {
-                    key: b"a".to_vec(),
-                    value: b"one".to_vec(),
-                },
-            ),
-            normal(
-                2,
-                RaftCommand::Batch {
-                    mutations: vec![
-                        RaftMutation::Set {
-                            key: b"b".to_vec(),
-                            value: b"two".to_vec(),
-                        },
-                        RaftMutation::Delete { key: b"a".to_vec() },
-                    ],
-                },
-            ),
-            normal(3, RaftCommand::Delete { key: b"missing".to_vec() }),
-        ];
-
-        let responses = state_machine.apply(entries).await.unwrap();
-        assert_eq!(
-            responses,
-            vec![
-                RaftResponse::Applied { mutations: 1 },
-                RaftResponse::Applied { mutations: 2 },
-                RaftResponse::Applied { mutations: 1 },
-            ]
-        );
-        assert_eq!(state_machine.get(b"a").await, None);
-        assert_eq!(state_machine.get(b"b").await, Some(b"two".to_vec()));
-        assert_eq!(state_machine.view().await.last_applied, Some(log_id(3)));
-    }
-
-    #[tokio::test]
-    async fn membership_entries_advance_metadata_without_mutating_kv_state() {
-        let mut state_machine = HomeKvStateMachine::default();
-        state_machine
-            .apply(vec![normal(
-                1,
-                RaftCommand::Set {
-                    key: b"stable".to_vec(),
-                    value: b"value".to_vec(),
-                },
-            )])
+    async fn applies_commands_in_committed_order() {
+        let mut sm = HomeKvStateMachine::default();
+        let responses = sm
+            .apply(vec![
+                normal(1, RaftCommand::Set { key: b"a".to_vec(), value: b"one".to_vec() }),
+                normal(2, RaftCommand::Batch { mutations: vec![
+                    RaftMutation::Set { key: b"b".to_vec(), value: b"two".to_vec() },
+                    RaftMutation::Delete { key: b"a".to_vec() },
+                ]}),
+                normal(3, RaftCommand::Delete { key: b"missing".to_vec() }),
+            ])
             .await
             .unwrap();
-        let before = state_machine.view().await.data;
 
-        state_machine.apply(vec![membership(2)]).await.unwrap();
-        let view = state_machine.view().await;
+        assert_eq!(responses, vec![
+            RaftResponse::Applied { mutations: 1 },
+            RaftResponse::Applied { mutations: 2 },
+            RaftResponse::Applied { mutations: 1 },
+        ]);
+        assert_eq!(sm.get(b"a").await, None);
+        assert_eq!(sm.get(b"b").await, Some(b"two".to_vec()));
+        assert_eq!(sm.view().await.last_applied, Some(log_id(3)));
+    }
 
+    #[tokio::test]
+    async fn membership_entry_updates_metadata_only() {
+        let mut sm = HomeKvStateMachine::default();
+        sm.apply(vec![normal(1, RaftCommand::Set { key: b"k".to_vec(), value: b"v".to_vec() })])
+            .await
+            .unwrap();
+        let before = sm.view().await.data;
+
+        let voters = BTreeSet::from([1, 2, 3]);
+        let membership = Membership::new(vec![voters], BTreeMap::<RaftNodeId, RaftNode>::new());
+        sm.apply(vec![Entry {
+            log_id: log_id(2),
+            payload: EntryPayload::Membership(membership),
+        }])
+        .await
+        .unwrap();
+
+        let view = sm.view().await;
         assert_eq!(view.data, before);
         assert_eq!(view.last_applied, Some(log_id(2)));
         assert_eq!(view.membership.log_id(), Some(log_id(2)));
     }
 
     #[tokio::test]
-    async fn replaying_the_same_committed_history_reconstructs_the_same_logical_state() {
-        fn history() -> Vec<Entry<HomeKvRaftConfig>> {
-            vec![
-                normal(
-                    1,
-                    RaftCommand::Set {
-                        key: b"k".to_vec(),
-                        value: b"v1".to_vec(),
-                    },
-                ),
-                normal(
-                    2,
-                    RaftCommand::Batch {
-                        mutations: vec![
-                            RaftMutation::Set {
-                                key: b"k".to_vec(),
-                                value: b"v2".to_vec(),
-                            },
-                            RaftMutation::Set {
-                                key: b"other".to_vec(),
-                                value: b"x".to_vec(),
-                            },
-                        ],
-                    },
-                ),
-                normal(3, RaftCommand::Delete { key: b"other".to_vec() }),
-            ]
-        }
-
+    async fn replay_is_deterministic_and_duplicate_identity_is_not_reapplied() {
+        let history = || vec![
+            normal(1, RaftCommand::Set { key: b"k".to_vec(), value: b"v1".to_vec() }),
+            normal(2, RaftCommand::Set { key: b"k".to_vec(), value: b"v2".to_vec() }),
+        ];
         let mut first = HomeKvStateMachine::default();
         let mut recovered = HomeKvStateMachine::default();
         first.apply(history()).await.unwrap();
         recovered.apply(history()).await.unwrap();
-
         assert_eq!(first.view().await, recovered.view().await);
+
+        let duplicate = normal(2, RaftCommand::Delete { key: b"k".to_vec() });
+        assert_eq!(first.apply(vec![duplicate]).await.unwrap(), vec![RaftResponse::Noop]);
+        assert_eq!(first.get(b"k").await, Some(b"v2".to_vec()));
     }
 
     #[tokio::test]
-    async fn repeated_log_identity_does_not_apply_twice_and_regression_fails_closed() {
-        let mut state_machine = HomeKvStateMachine::default();
-        let entry = normal(
-            1,
-            RaftCommand::Set {
-                key: b"k".to_vec(),
-                value: b"v".to_vec(),
-            },
-        );
-
-        assert_eq!(
-            state_machine.apply(vec![entry.clone()]).await.unwrap(),
-            vec![RaftResponse::Applied { mutations: 1 }]
-        );
-        assert_eq!(
-            state_machine.apply(vec![entry]).await.unwrap(),
-            vec![RaftResponse::Noop]
-        );
-
-        state_machine
-            .apply(vec![normal(
-                2,
-                RaftCommand::Set {
-                    key: b"k".to_vec(),
-                    value: b"v2".to_vec(),
-                },
-            )])
+    async fn lower_log_index_fails_closed() {
+        let mut sm = HomeKvStateMachine::default();
+        sm.apply(vec![normal(2, RaftCommand::Set { key: b"k".to_vec(), value: b"v".to_vec() })])
             .await
             .unwrap();
-        let before = state_machine.view().await;
-
-        assert!(state_machine
-            .apply(vec![normal(
-                1,
-                RaftCommand::Delete { key: b"k".to_vec() },
-            )])
-            .await
-            .is_err());
-        assert_eq!(state_machine.view().await, before);
-    }
-
-    #[tokio::test]
-    async fn empty_batch_is_deterministic_and_does_not_mutate_kv_state() {
-        let mut state_machine = HomeKvStateMachine::default();
-        let responses = state_machine
-            .apply(vec![normal(
-                1,
-                RaftCommand::Batch { mutations: vec![] },
-            )])
-            .await
-            .unwrap();
-
-        assert_eq!(responses, vec![RaftResponse::EmptyBatch]);
-        assert!(state_machine.view().await.data.is_empty());
-        assert_eq!(state_machine.view().await.last_applied, Some(log_id(1)));
+        let before = sm.view().await;
+        assert!(sm.apply(vec![normal(1, RaftCommand::Delete { key: b"k".to_vec() })]).await.is_err());
+        assert_eq!(sm.view().await, before);
     }
 }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1,0 +1,422 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::io;
+use std::sync::Arc;
+
+use openraft::storage::{RaftStateMachine, Snapshot};
+use openraft::{
+    BasicNode, Entry, EntryPayload, LogId, RaftSnapshotBuilder, SnapshotMeta, StorageError,
+    StorageIOError, StoredMembership,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+pub type RaftNodeId = u64;
+pub type RaftNode = BasicNode;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum RaftMutation {
+    Set { key: Vec<u8>, value: Vec<u8> },
+    Delete { key: Vec<u8> },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum RaftCommand {
+    Set { key: Vec<u8>, value: Vec<u8> },
+    Delete { key: Vec<u8> },
+    Batch { mutations: Vec<RaftMutation> },
+}
+
+impl fmt::Display for RaftCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Set { key, value } => write!(f, "set({},{})", key.len(), value.len()),
+            Self::Delete { key } => write!(f, "delete({})", key.len()),
+            Self::Batch { mutations } => write!(f, "batch({})", mutations.len()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum RaftResponse {
+    Applied { mutations: u32 },
+    EmptyBatch,
+    Noop,
+}
+
+impl fmt::Display for RaftResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Applied { mutations } => write!(f, "applied({mutations})"),
+            Self::EmptyBatch => write!(f, "empty-batch"),
+            Self::Noop => write!(f, "noop"),
+        }
+    }
+}
+
+openraft::declare_raft_types!(
+    pub HomeKvRaftConfig:
+        D = RaftCommand,
+        R = RaftResponse,
+        NodeId = RaftNodeId,
+        Node = RaftNode,
+);
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StateMachineView {
+    pub last_applied: Option<LogId<RaftNodeId>>,
+    pub membership: StoredMembership<RaftNodeId, RaftNode>,
+    pub data: BTreeMap<Vec<u8>, Vec<u8>>,
+}
+
+#[derive(Debug, Default)]
+struct StateMachineData {
+    last_applied: Option<LogId<RaftNodeId>>,
+    membership: StoredMembership<RaftNodeId, RaftNode>,
+    data: BTreeMap<Vec<u8>, Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct HomeKvStateMachine {
+    inner: Arc<RwLock<StateMachineData>>,
+}
+
+impl HomeKvStateMachine {
+    pub async fn view(&self) -> StateMachineView {
+        let state = self.inner.read().await;
+        StateMachineView {
+            last_applied: state.last_applied,
+            membership: state.membership.clone(),
+            data: state.data.clone(),
+        }
+    }
+
+    pub async fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.inner.read().await.data.get(key).cloned()
+    }
+
+    fn storage_error(message: &'static str) -> StorageError<RaftNodeId> {
+        let err = io::Error::new(io::ErrorKind::InvalidData, message);
+        StorageIOError::read_state_machine(&err).into()
+    }
+
+    fn apply_command(state: &mut StateMachineData, command: RaftCommand) -> RaftResponse {
+        match command {
+            RaftCommand::Set { key, value } => {
+                state.data.insert(key, value);
+                RaftResponse::Applied { mutations: 1 }
+            }
+            RaftCommand::Delete { key } => {
+                state.data.remove(&key);
+                RaftResponse::Applied { mutations: 1 }
+            }
+            RaftCommand::Batch { mutations } => {
+                if mutations.is_empty() {
+                    return RaftResponse::EmptyBatch;
+                }
+
+                for mutation in &mutations {
+                    match mutation {
+                        RaftMutation::Set { key, value } => {
+                            state.data.insert(key.clone(), value.clone());
+                        }
+                        RaftMutation::Delete { key } => {
+                            state.data.remove(key);
+                        }
+                    }
+                }
+                RaftResponse::Applied {
+                    mutations: mutations.len() as u32,
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DeferredSnapshotBuilder;
+
+impl RaftSnapshotBuilder<HomeKvRaftConfig> for DeferredSnapshotBuilder {
+    async fn build_snapshot(
+        &mut self,
+    ) -> Result<Snapshot<HomeKvRaftConfig>, StorageError<RaftNodeId>> {
+        Err(HomeKvStateMachine::storage_error(
+            "snapshot build is deferred to accepted M3-T5",
+        ))
+    }
+}
+
+impl RaftStateMachine<HomeKvRaftConfig> for HomeKvStateMachine {
+    type SnapshotBuilder = DeferredSnapshotBuilder;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<
+        (
+            Option<LogId<RaftNodeId>>,
+            StoredMembership<RaftNodeId, RaftNode>,
+        ),
+        StorageError<RaftNodeId>,
+    > {
+        let state = self.inner.read().await;
+        Ok((state.last_applied, state.membership.clone()))
+    }
+
+    async fn apply<I>(
+        &mut self,
+        entries: I,
+    ) -> Result<Vec<RaftResponse>, StorageError<RaftNodeId>>
+    where
+        I: IntoIterator<Item = Entry<HomeKvRaftConfig>> + Send,
+    {
+        let mut responses = Vec::new();
+        let mut state = self.inner.write().await;
+
+        for entry in entries {
+            if let Some(last) = state.last_applied {
+                if entry.log_id == last {
+                    responses.push(RaftResponse::Noop);
+                    continue;
+                }
+                if entry.log_id.index <= last.index {
+                    return Err(Self::storage_error(
+                        "state-machine apply order regressed or reused a log index",
+                    ));
+                }
+            }
+
+            let response = match entry.payload {
+                EntryPayload::Blank => RaftResponse::Noop,
+                EntryPayload::Normal(command) => Self::apply_command(&mut state, command),
+                EntryPayload::Membership(membership) => {
+                    state.membership = StoredMembership::new(Some(entry.log_id), membership);
+                    RaftResponse::Noop
+                }
+            };
+
+            state.last_applied = Some(entry.log_id);
+            responses.push(response);
+        }
+
+        Ok(responses)
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        DeferredSnapshotBuilder
+    }
+
+    async fn begin_receiving_snapshot(
+        &mut self,
+    ) -> Result<
+        Box<<HomeKvRaftConfig as openraft::RaftTypeConfig>::SnapshotData>,
+        StorageError<RaftNodeId>,
+    > {
+        Err(Self::storage_error(
+            "snapshot receiving is deferred to accepted M3-T5",
+        ))
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        _meta: &SnapshotMeta<RaftNodeId, RaftNode>,
+        _snapshot: Box<<HomeKvRaftConfig as openraft::RaftTypeConfig>::SnapshotData>,
+    ) -> Result<(), StorageError<RaftNodeId>> {
+        Err(Self::storage_error(
+            "snapshot installation is deferred to accepted M3-T5",
+        ))
+    }
+
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<HomeKvRaftConfig>>, StorageError<RaftNodeId>> {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use openraft::{CommittedLeaderId, Membership};
+
+    use super::*;
+
+    fn log_id(index: u64) -> LogId<RaftNodeId> {
+        LogId::new(CommittedLeaderId::new(1, 1), index)
+    }
+
+    fn normal(index: u64, command: RaftCommand) -> Entry<HomeKvRaftConfig> {
+        Entry {
+            log_id: log_id(index),
+            payload: EntryPayload::Normal(command),
+        }
+    }
+
+    fn membership(index: u64) -> Entry<HomeKvRaftConfig> {
+        let voters = BTreeSet::from([1, 2, 3]);
+        let membership = Membership::new(vec![voters], BTreeMap::<RaftNodeId, RaftNode>::new());
+        Entry {
+            log_id: log_id(index),
+            payload: EntryPayload::Membership(membership),
+        }
+    }
+
+    #[tokio::test]
+    async fn applies_commands_in_committed_order_with_m1_semantics() {
+        let mut state_machine = HomeKvStateMachine::default();
+        let entries = vec![
+            normal(
+                1,
+                RaftCommand::Set {
+                    key: b"a".to_vec(),
+                    value: b"one".to_vec(),
+                },
+            ),
+            normal(
+                2,
+                RaftCommand::Batch {
+                    mutations: vec![
+                        RaftMutation::Set {
+                            key: b"b".to_vec(),
+                            value: b"two".to_vec(),
+                        },
+                        RaftMutation::Delete { key: b"a".to_vec() },
+                    ],
+                },
+            ),
+            normal(3, RaftCommand::Delete { key: b"missing".to_vec() }),
+        ];
+
+        let responses = state_machine.apply(entries).await.unwrap();
+        assert_eq!(
+            responses,
+            vec![
+                RaftResponse::Applied { mutations: 1 },
+                RaftResponse::Applied { mutations: 2 },
+                RaftResponse::Applied { mutations: 1 },
+            ]
+        );
+        assert_eq!(state_machine.get(b"a").await, None);
+        assert_eq!(state_machine.get(b"b").await, Some(b"two".to_vec()));
+        assert_eq!(state_machine.view().await.last_applied, Some(log_id(3)));
+    }
+
+    #[tokio::test]
+    async fn membership_entries_advance_metadata_without_mutating_kv_state() {
+        let mut state_machine = HomeKvStateMachine::default();
+        state_machine
+            .apply(vec![normal(
+                1,
+                RaftCommand::Set {
+                    key: b"stable".to_vec(),
+                    value: b"value".to_vec(),
+                },
+            )])
+            .await
+            .unwrap();
+        let before = state_machine.view().await.data;
+
+        state_machine.apply(vec![membership(2)]).await.unwrap();
+        let view = state_machine.view().await;
+
+        assert_eq!(view.data, before);
+        assert_eq!(view.last_applied, Some(log_id(2)));
+        assert_eq!(view.membership.log_id(), Some(log_id(2)));
+    }
+
+    #[tokio::test]
+    async fn replaying_the_same_committed_history_reconstructs_the_same_logical_state() {
+        fn history() -> Vec<Entry<HomeKvRaftConfig>> {
+            vec![
+                normal(
+                    1,
+                    RaftCommand::Set {
+                        key: b"k".to_vec(),
+                        value: b"v1".to_vec(),
+                    },
+                ),
+                normal(
+                    2,
+                    RaftCommand::Batch {
+                        mutations: vec![
+                            RaftMutation::Set {
+                                key: b"k".to_vec(),
+                                value: b"v2".to_vec(),
+                            },
+                            RaftMutation::Set {
+                                key: b"other".to_vec(),
+                                value: b"x".to_vec(),
+                            },
+                        ],
+                    },
+                ),
+                normal(3, RaftCommand::Delete { key: b"other".to_vec() }),
+            ]
+        }
+
+        let mut first = HomeKvStateMachine::default();
+        let mut recovered = HomeKvStateMachine::default();
+        first.apply(history()).await.unwrap();
+        recovered.apply(history()).await.unwrap();
+
+        assert_eq!(first.view().await, recovered.view().await);
+    }
+
+    #[tokio::test]
+    async fn repeated_log_identity_does_not_apply_twice_and_regression_fails_closed() {
+        let mut state_machine = HomeKvStateMachine::default();
+        let entry = normal(
+            1,
+            RaftCommand::Set {
+                key: b"k".to_vec(),
+                value: b"v".to_vec(),
+            },
+        );
+
+        assert_eq!(
+            state_machine.apply(vec![entry.clone()]).await.unwrap(),
+            vec![RaftResponse::Applied { mutations: 1 }]
+        );
+        assert_eq!(
+            state_machine.apply(vec![entry]).await.unwrap(),
+            vec![RaftResponse::Noop]
+        );
+
+        state_machine
+            .apply(vec![normal(
+                2,
+                RaftCommand::Set {
+                    key: b"k".to_vec(),
+                    value: b"v2".to_vec(),
+                },
+            )])
+            .await
+            .unwrap();
+        let before = state_machine.view().await;
+
+        assert!(state_machine
+            .apply(vec![normal(
+                1,
+                RaftCommand::Delete { key: b"k".to_vec() },
+            )])
+            .await
+            .is_err());
+        assert_eq!(state_machine.view().await, before);
+    }
+
+    #[tokio::test]
+    async fn empty_batch_is_deterministic_and_does_not_mutate_kv_state() {
+        let mut state_machine = HomeKvStateMachine::default();
+        let responses = state_machine
+            .apply(vec![normal(
+                1,
+                RaftCommand::Batch { mutations: vec![] },
+            )])
+            .await
+            .unwrap();
+
+        assert_eq!(responses, vec![RaftResponse::EmptyBatch]);
+        assert!(state_machine.view().await.data.is_empty());
+        assert_eq!(state_machine.view().await.last_applied, Some(log_id(1)));
+    }
+}


### PR DESCRIPTION
## SDD scope

Implements **M3-T1 only** from Accepted Spec 0005 (`specs/0005-three-node-openraft/`).

Requirements covered: `REQ-M3-RAFT-001..003`, `REQ-M3-SM-001..005`.

## Changes

- pin `openraft = "=0.9.25"` exactly;
- define HomeKV-owned OpenRaft type config, node aliases, deterministic SET/DELETE/BATCH commands and responses;
- add a one-shard `RaftStateMachine` application boundary;
- retain/expose last-applied log identity and OpenRaft membership metadata;
- reject regressed/reused log indexes fail-closed and suppress repeated exact log identity from reapplication;
- add deterministic application, membership, replay/recovery-oriented, duplicate-log-id, and empty-batch tests;
- keep snapshot hooks explicitly deferred/fail-closed for M3-T5.

## Explicitly out of scope

No durable WAL/vote storage, production Raft transport, cluster bootstrap, replicated client serving, linearizable GET integration, snapshots, failover/recovery runtime, or Multi-Raft work.

## Gates

Merge only after the normal Rust workflow passes build, full tests, and all preserved M0 smoke gates.

Tracking: #38, parent #7.