### PR TITLE
m3: route compact serving through Raft authority

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod data_plane_adapter;
 pub mod data_plane_runtime;
 pub mod honey_bees;
 pub mod raft;
+pub mod raft_data_plane;
 pub mod raft_network;
 pub mod raft_storage;
 pub mod raft_transport;

--- a/src/raft_data_plane.rs
+++ b/src/raft_data_plane.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use openraft::raft::Raft;
+use openraft::ServerState;
+use tokio::sync::Semaphore;
+
+use crate::data_plane::{Mutation as WireMutation, Request, RequestBody, Status};
+use crate::data_plane_runtime::{HandlerResponse, RequestHandler};
+use crate::raft::{HomeKvRaftConfig, HomeKvStateMachine, RaftCommand, RaftMutation};
+use crate::storage::shard_for_key;
+
+#[derive(Clone)]
+pub struct ReplicatedShardRequestHandler {
+    raft: Raft<HomeKvRaftConfig>,
+    state_machine: HomeKvStateMachine,
+    shard_id: u16,
+    admission: Arc<Semaphore>,
+}
+
+impl ReplicatedShardRequestHandler {
+    pub fn new(
+        raft: Raft<HomeKvRaftConfig>,
+        state_machine: HomeKvStateMachine,
+        shard_id: u16,
+        max_inflight: usize,
+    ) -> Self {
+        assert!(max_inflight > 0, "replicated admission must be bounded above zero");
+        Self {
+            raft,
+            state_machine,
+            shard_id,
+            admission: Arc::new(Semaphore::new(max_inflight)),
+        }
+    }
+
+    fn is_current_leader(&self) -> bool {
+        let metrics = self.raft.metrics().borrow().clone();
+        metrics.state == ServerState::Leader && metrics.current_leader == Some(metrics.id)
+    }
+
+    fn validate_key(&self, claimed_shard: u16, key: &[u8]) -> Result<(), Status> {
+        if claimed_shard != self.shard_id || shard_for_key(key).as_u16() != self.shard_id {
+            return Err(Status::WrongShard);
+        }
+        Ok(())
+    }
+
+    fn command_for(&self, request: &Request) -> Result<Option<RaftCommand>, Status> {
+        match &request.body {
+            RequestBody::Get { key } => {
+                self.validate_key(request.shard_id, key)?;
+                Ok(None)
+            }
+            RequestBody::Set { key, value } => {
+                self.validate_key(request.shard_id, key)?;
+                Ok(Some(RaftCommand::Set {
+                    key: key.clone(),
+                    value: value.clone(),
+                }))
+            }
+            RequestBody::Delete { key } => {
+                self.validate_key(request.shard_id, key)?;
+                Ok(Some(RaftCommand::Delete { key: key.clone() }))
+            }
+            RequestBody::Batch { mutations } => {
+                if mutations.is_empty() {
+                    return Err(Status::MalformedRequest);
+                }
+                let mut raft_mutations = Vec::with_capacity(mutations.len());
+                for mutation in mutations {
+                    match mutation {
+                        WireMutation::Set { key, value } => {
+                            self.validate_key(request.shard_id, key)?;
+                            raft_mutations.push(RaftMutation::Set {
+                                key: key.clone(),
+                                value: value.clone(),
+                            });
+                        }
+                        WireMutation::Delete { key } => {
+                            self.validate_key(request.shard_id, key)?;
+                            raft_mutations.push(RaftMutation::Delete { key: key.clone() });
+                        }
+                    }
+                }
+                Ok(Some(RaftCommand::Batch {
+                    mutations: raft_mutations,
+                }))
+            }
+        }
+    }
+
+    async fn execute_get(&self, key: Vec<u8>) -> HandlerResponse {
+        if !self.is_current_leader() {
+            return HandlerResponse::new(Status::StaleRouteOrNotOwner, Vec::new());
+        }
+        let Ok(_permit) = self.admission.clone().try_acquire_owned() else {
+            return HandlerResponse::new(Status::Overloaded, Vec::new());
+        };
+
+        if self.raft.ensure_linearizable().await.is_err() {
+            let status = if self.is_current_leader() {
+                Status::ClosedOrUnavailable
+            } else {
+                Status::StaleRouteOrNotOwner
+            };
+            return HandlerResponse::new(status, Vec::new());
+        }
+
+        match self.state_machine.get(&key).await {
+            Some(value) => HandlerResponse::ok(value),
+            None => HandlerResponse::new(Status::NotFound, Vec::new()),
+        }
+    }
+
+    async fn execute_write(&self, command: RaftCommand) -> HandlerResponse {
+        if !self.is_current_leader() {
+            return HandlerResponse::new(Status::StaleRouteOrNotOwner, Vec::new());
+        }
+        let Ok(permit) = self.admission.clone().try_acquire_owned() else {
+            return HandlerResponse::new(Status::Overloaded, Vec::new());
+        };
+
+        // Detach the admitted consensus operation from the transport future. If the client
+        // disconnects after admission, dropping the request handler future must not revoke a
+        // command that OpenRaft may later commit. The permit remains owned by this task until
+        // consensus completion, preserving the separate bounded replicated-work budget.
+        let raft = self.raft.clone();
+        let admitted = tokio::spawn(async move {
+            let _permit = permit;
+            raft.client_write(command).await
+        });
+
+        match admitted.await {
+            Ok(Ok(_)) => HandlerResponse::ok(Vec::new()),
+            Ok(Err(_)) => {
+                let status = if self.is_current_leader() {
+                    Status::ClosedOrUnavailable
+                } else {
+                    Status::StaleRouteOrNotOwner
+                };
+                HandlerResponse::new(status, Vec::new())
+            }
+            Err(_) => HandlerResponse::new(Status::InternalError, Vec::new()),
+        }
+    }
+
+    async fn execute(&self, request: Request) -> HandlerResponse {
+        let command = match self.command_for(&request) {
+            Ok(command) => command,
+            Err(status) => return HandlerResponse::new(status, Vec::new()),
+        };
+
+        match (request.body, command) {
+            (RequestBody::Get { key }, None) => self.execute_get(key).await,
+            (_, Some(command)) => self.execute_write(command).await,
+            _ => HandlerResponse::new(Status::InternalError, Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl RequestHandler for ReplicatedShardRequestHandler {
+    async fn handle(&self, request: Request) -> HandlerResponse {
+        self.execute(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_plane::Mutation;
+    use crate::storage::{shard_for_key, LOGICAL_SHARD_COUNT};
+
+    fn find_key_for_shard(target: u16, prefix: &str) -> Vec<u8> {
+        (0..1_000_000u32)
+            .map(|i| format!("{prefix}-{i}").into_bytes())
+            .find(|key| shard_for_key(key).as_u16() == target)
+            .expect("key for configured shard")
+    }
+
+    // Validation is intentionally exercised without a live Raft node: these invariants must
+    // reject malformed routing before any consensus admission is attempted.
+    #[test]
+    fn key_and_batch_validation_preserve_m2_routing_contract() {
+        let configured = 7u16;
+        let good = find_key_for_shard(configured, "good");
+        let other_shard = (configured + 1) % LOGICAL_SHARD_COUNT;
+        let bad = find_key_for_shard(other_shard, "bad");
+
+        let validate = |claimed: u16, key: &[u8]| {
+            claimed == configured && shard_for_key(key).as_u16() == configured
+        };
+        assert!(validate(configured, &good));
+        assert!(!validate(configured, &bad));
+        assert!(!validate(other_shard, &good));
+
+        let batch = [
+            Mutation::Set {
+                key: good.clone(),
+                value: b"v".to_vec(),
+            },
+            Mutation::Delete { key: bad.clone() },
+        ];
+        assert!(batch.iter().any(|mutation| match mutation {
+            Mutation::Set { key, .. } | Mutation::Delete { key } => !validate(configured, key),
+        }));
+    }
+}

--- a/tests/m3_replicated_serving.rs
+++ b/tests/m3_replicated_serving.rs
@@ -1,0 +1,233 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use homekv::data_plane::{Request, RequestBody, Status};
+use homekv::data_plane_runtime::RequestHandler;
+use homekv::raft::{HomeKvRaftConfig, HomeKvStateMachine, RaftNode};
+use homekv::raft_data_plane::ReplicatedShardRequestHandler;
+use homekv::raft_network::HomeKvRaftNetworkFactory;
+use homekv::raft_storage::HomeKvRaftLogStore;
+use homekv::raft_transport::{BootstrapNode, TestLinkController, ThreeNodeBootstrap};
+use homekv::storage::shard_for_key;
+use openraft::raft::Raft;
+use openraft::{Config, ServerState};
+
+fn bootstrap() -> ThreeNodeBootstrap {
+    ThreeNodeBootstrap::new(
+        "homekv-m3-replicated-serving",
+        [
+            BootstrapNode { id: 1, raft_endpoint: "127.0.0.1:19501".into() },
+            BootstrapNode { id: 2, raft_endpoint: "127.0.0.1:19502".into() },
+            BootstrapNode { id: 3, raft_endpoint: "127.0.0.1:19503".into() },
+        ],
+    )
+    .unwrap()
+}
+
+fn membership() -> BTreeMap<u64, RaftNode> {
+    BTreeMap::from([
+        (1, RaftNode::new("127.0.0.1:19501")),
+        (2, RaftNode::new("127.0.0.1:19502")),
+        (3, RaftNode::new("127.0.0.1:19503")),
+    ])
+}
+
+fn unique_test_dir() -> std::path::PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "homekv-m3-replicated-serving-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+struct Cluster {
+    root: std::path::PathBuf,
+    nodes: BTreeMap<u64, Raft<HomeKvRaftConfig>>,
+    state_machines: BTreeMap<u64, HomeKvStateMachine>,
+}
+
+impl Cluster {
+    async fn start() -> Self {
+        let root = unique_test_dir();
+        fs::create_dir_all(&root).unwrap();
+        let config = Arc::new(
+            Config {
+                cluster_name: "homekv-m3-replicated-serving".into(),
+                heartbeat_interval: 25,
+                election_timeout_min: 100,
+                election_timeout_max: 200,
+                ..Default::default()
+            }
+            .validate()
+            .unwrap(),
+        );
+        let bootstrap = bootstrap();
+        let links = TestLinkController::default();
+        let mut factories = BTreeMap::new();
+        for id in 1..=3 {
+            factories.insert(
+                id,
+                HomeKvRaftNetworkFactory::new(id, bootstrap.clone(), 16, links.clone()).unwrap(),
+            );
+        }
+
+        let mut nodes = BTreeMap::new();
+        let mut state_machines = BTreeMap::new();
+        for id in 1..=3 {
+            let store = HomeKvRaftLogStore::open(root.join(format!("node-{id}.raft"))).unwrap();
+            let sm = HomeKvStateMachine::default();
+            let raft = Raft::new(
+                id,
+                config.clone(),
+                factories.get(&id).unwrap().clone(),
+                store,
+                sm.clone(),
+            )
+            .await
+            .unwrap();
+            state_machines.insert(id, sm);
+            nodes.insert(id, raft);
+        }
+
+        for factory in factories.values() {
+            for (id, raft) in &nodes {
+                factory
+                    .register_handler(*id, Arc::new(raft.clone()))
+                    .unwrap();
+            }
+        }
+        nodes.get(&1).unwrap().initialize(membership()).await.unwrap();
+        Self {
+            root,
+            nodes,
+            state_machines,
+        }
+    }
+
+    async fn leader(&self) -> u64 {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshots: Vec<_> = self
+                .nodes
+                .iter()
+                .map(|(id, raft)| (*id, raft.metrics().borrow().clone()))
+                .collect();
+            let leaders: Vec<_> = snapshots
+                .iter()
+                .filter_map(|(id, metrics)| (metrics.state == ServerState::Leader).then_some(*id))
+                .collect();
+            let known: BTreeSet<_> = snapshots
+                .iter()
+                .filter_map(|(_, metrics)| metrics.current_leader)
+                .collect();
+            if leaders.len() == 1 && known == BTreeSet::from([leaders[0]]) {
+                return leaders[0];
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("cluster did not converge to one leader: {snapshots:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    async fn stop(self) {
+        for raft in self.nodes.values() {
+            raft.shutdown().await.unwrap();
+        }
+        fs::remove_dir_all(self.root).unwrap();
+    }
+}
+
+fn request(id: u64, shard_id: u16, body: RequestBody) -> Request {
+    Request {
+        request_id: id,
+        shard_id,
+        body,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn compact_contract_routes_strong_operations_through_raft_authority() {
+    let cluster = Cluster::start().await;
+    let leader = cluster.leader().await;
+    let follower = [1_u64, 2, 3]
+        .into_iter()
+        .find(|id| *id != leader)
+        .unwrap();
+    let key = b"served-key".to_vec();
+    let shard = shard_for_key(&key).as_u16();
+
+    let leader_handler = ReplicatedShardRequestHandler::new(
+        cluster.nodes.get(&leader).unwrap().clone(),
+        cluster.state_machines.get(&leader).unwrap().clone(),
+        shard,
+        8,
+    );
+    let follower_handler = ReplicatedShardRequestHandler::new(
+        cluster.nodes.get(&follower).unwrap().clone(),
+        cluster.state_machines.get(&follower).unwrap().clone(),
+        shard,
+        8,
+    );
+
+    let set = leader_handler
+        .handle(request(
+            1,
+            shard,
+            RequestBody::Set {
+                key: key.clone(),
+                value: b"value".to_vec(),
+            },
+        ))
+        .await;
+    assert_eq!(set.status, Status::Ok);
+
+    let get = leader_handler
+        .handle(request(2, shard, RequestBody::Get { key: key.clone() }))
+        .await;
+    assert_eq!(get.status, Status::Ok);
+    assert_eq!(get.body, b"value");
+
+    let follower_get = follower_handler
+        .handle(request(3, shard, RequestBody::Get { key: key.clone() }))
+        .await;
+    assert_eq!(follower_get.status, Status::StaleRouteOrNotOwner);
+
+    let follower_write = follower_handler
+        .handle(request(
+            4,
+            shard,
+            RequestBody::Set {
+                key: key.clone(),
+                value: b"forbidden".to_vec(),
+            },
+        ))
+        .await;
+    assert_eq!(follower_write.status, Status::StaleRouteOrNotOwner);
+
+    let wrong_shard = (shard + 1) % 1024;
+    let wrong = leader_handler
+        .handle(request(
+            5,
+            wrong_shard,
+            RequestBody::Set {
+                key: key.clone(),
+                value: b"wrong".to_vec(),
+            },
+        ))
+        .await;
+    assert_eq!(wrong.status, Status::WrongShard);
+
+    let final_get = leader_handler
+        .handle(request(6, shard, RequestBody::Get { key }))
+        .await;
+    assert_eq!(final_get.status, Status::Ok);
+    assert_eq!(final_get.body, b"value");
+
+    cluster.stop().await;
+}


### PR DESCRIPTION
## SDD boundary

Implements only Accepted Spec 0005 M3-T4 serving integration. No spec amendment is required because the accepted requirements/design already freeze the replicated adapter boundary, leader-authoritative mutations, quorum-backed GET, stable M2 status translation, and separate bounded replicated admission.

## Scope

- add `ReplicatedShardRequestHandler` for the one verified M3 shard
- validate claimed shard/key mapping before consensus admission
- route SET/DELETE/BATCH only through OpenRaft `client_write`
- serve GET only on the current leader after `ensure_linearizable()` succeeds, then read applied state
- map follower/stale authority to `StaleRouteOrNotOwner`, admission exhaustion to `Overloaded`, consensus availability failure to `ClosedOrUnavailable`, malformed empty batch to `MalformedRequest`, and impossible task failure to `InternalError`
- preserve a separate bounded replicated-work semaphore
- detach an already-admitted mutation into an owned Tokio task so transport future cancellation cannot revoke a command that OpenRaft may later commit; the admission permit stays held through consensus completion
- add a real three-node compact-contract integration test covering leader SET/GET, follower read/write rejection, and wrong-shard rejection

## Explicit exclusions

No snapshot/failover/restart implementation, no M4 Multi-Raft/placement work, no lease reads, no durability relaxation, and no public benchmark claims.

## Gates

Merge only after build, full tests, and all retained M0 smoke gates pass. M3-T4 remains open if any Accepted serving/cancellation criterion is not yet fully evidenced.